### PR TITLE
refactor : 카카오 회원가입 toEntity 리팩토링 

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/auth/service/AuthService.java
@@ -59,12 +59,7 @@ public class AuthService {
     }
 
     public User createKakaoUser(KakaoUserInfoResponse kakaoUserInfoResponse){
-        User user = User.builder()
-                .snsId(kakaoUserInfoResponse.getId())
-                .email(kakaoUserInfoResponse.getEmail())
-                .snsType(SnsType.KAKAO)
-                .build();
-
+        User user = kakaoUserInfoResponse.toEntity();
         return userRepository.save(user);
     }
 

--- a/src/main/java/com/clubber/ClubberServer/global/infrastructure/outer/api/oauth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/global/infrastructure/outer/api/oauth/dto/KakaoUserInfoResponse.java
@@ -1,5 +1,7 @@
 package com.clubber.ClubberServer.global.infrastructure.outer.api.oauth.dto;
 
+import com.clubber.ClubberServer.domain.user.domain.SnsType;
+import com.clubber.ClubberServer.domain.user.domain.User;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
@@ -21,5 +23,13 @@ public class KakaoUserInfoResponse {
 
     public String getEmail(){
         return kakaoAccount.getEmail();
+    }
+
+    public User toEntity(){
+        return User.builder()
+                .email(getEmail())
+                .snsType(SnsType.KAKAO)
+                .snsId(id)
+                .build();
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
#24 
#158 

## Key Changes
- [x] 카카오 회원가입 시 response로 받은 유저 정보를 service 계층이 아닌 dto 내부에서 User Entity로 변환 

## ETC 
