### PR TITLE
feat : 관리자 모집글 수정 api 구현

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
@@ -1,10 +1,8 @@
 package com.clubber.ClubberServer.domain.recruit.controller;
 
 
-import com.clubber.ClubberServer.domain.recruit.dto.DeleteRecruitByIdResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.GetOneRecruitResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.PostRecruitRequest;
-import com.clubber.ClubberServer.domain.recruit.dto.PostRecruitResponse;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateClubPageRequest;
+import com.clubber.ClubberServer.domain.recruit.dto.*;
 import com.clubber.ClubberServer.domain.recruit.service.RecruitService;
 import com.clubber.ClubberServer.global.page.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,5 +46,12 @@ public class adminRecruitController {
     public GetOneRecruitResponse getOneAdminRecruitsById(@PathVariable("recruitId")Long recruitId){
         return recruitService.getOneAdminRecruitsById(recruitId);
     }
+
+//    @PatchMapping("/admins/recruits/{recruitId}")
+//    @Operation(summary= " 동아리 계정 개별 모집글 수정")
+//    public UpdateRecruitResponse changeAdminRecruits(@PathVariable("recruitId")Long recruitId,@RequestBody @Valid UpdateRecruitRequest pageRequest){
+//        return recruitService.changeAdminRecruits(recruitId,pageRequest);
+//    }
+
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
@@ -47,11 +47,11 @@ public class adminRecruitController {
         return recruitService.getOneAdminRecruitsById(recruitId);
     }
 
-//    @PatchMapping("/admins/recruits/{recruitId}")
-//    @Operation(summary= " 동아리 계정 개별 모집글 수정")
-//    public UpdateRecruitResponse changeAdminRecruits(@PathVariable("recruitId")Long recruitId,@RequestBody @Valid UpdateRecruitRequest pageRequest){
-//        return recruitService.changeAdminRecruits(recruitId,pageRequest);
-//    }
+    @PatchMapping("/admins/recruits/{recruitId}")
+    @Operation(summary= " 동아리 계정 개별 모집글 수정")
+    public UpdateRecruitResponse changeAdminRecruits(@PathVariable("recruitId")Long recruitId,@RequestBody @Valid UpdateRecruitRequest pageRequest){
+        return recruitService.changeAdminRecruits(recruitId,pageRequest);
+    }
 
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
@@ -3,6 +3,7 @@ package com.clubber.ClubberServer.domain.recruit.domain;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.common.BaseEntity;
 import com.clubber.ClubberServer.domain.recruit.dto.PostRecruitRequest;
+import com.clubber.ClubberServer.global.vo.ImageVO;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -49,6 +50,12 @@ public class Recruit extends BaseEntity {
     public void increaseTotalview(){
         this.totalView++;
     }
+
+    public void updateRecruitPage(String title, String content){
+        this.title=title;
+        this.content=content;
+    }
+
 
     @Builder
     private Recruit(Long id,String title,String content,Long totalView,Club club,boolean isDeleted,List<RecruitImage> recruitImages){

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/RecruitImage.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/RecruitImage.java
@@ -24,6 +24,10 @@ public class RecruitImage extends BaseEntity {
     @JoinColumn(name = "recruit_id", nullable = false)
     private Recruit recruit;
 
+    private Long orderNum;
+
+    private boolean isDeleted=false;
+
     @Builder
     private RecruitImage(Long id, ImageVO imageUrl,Recruit recruit){
         this.id=id;
@@ -37,5 +41,9 @@ public class RecruitImage extends BaseEntity {
                 .recruit(recruit)
                 .build();
     }
+
+    public void updateStatus(){this.isDeleted=true;}
+
+    public void updateOrderNum(Long orderNum){this.orderNum=orderNum;}
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
@@ -1,0 +1,21 @@
+package com.clubber.ClubberServer.domain.recruit.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateRecruitRequest {
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+
+    private List<String> imageUrl;
+
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
@@ -16,6 +16,8 @@ public class UpdateRecruitRequest {
     @NotNull
     private String content;
 
-    private List<String> imageUrl;
+    private List<String> deletedImageKeys;
+
+    private List<String> createdImageKeys;
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
@@ -17,14 +17,13 @@ public class UpdateRecruitRequest {
     @NotNull
     private String content;
 
-    private List<String> deletedImageUrls; //삭제
+    private List<String> deletedImageUrls;
 
-    private List<String> newImageKeys; //추가
+    private List<String> newImageKeys;
 
-    private List<String> remainImageUrls; //유지
+    private List<String> remainImageUrls;
 
-    private List<String> images; //최종(추가+유지) - 저장할 순서대로 담겨져 있음
+    private List<String> images;
 
-    private List<Long> order;
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitRequest.java
@@ -1,5 +1,6 @@
 package com.clubber.ClubberServer.domain.recruit.dto;
 
+import com.clubber.ClubberServer.global.vo.ImageVO;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,8 +17,14 @@ public class UpdateRecruitRequest {
     @NotNull
     private String content;
 
-    private List<String> deletedImageKeys;
+    private List<String> deletedImageUrls; //삭제
 
-    private List<String> createdImageKeys;
+    private List<String> newImageKeys; //추가
+
+    private List<String> remainImageUrls; //유지
+
+    private List<String> images; //최종(추가+유지) - 저장할 순서대로 담겨져 있음
+
+    private List<Long> order;
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
@@ -1,0 +1,32 @@
+package com.clubber.ClubberServer.domain.recruit.dto;
+
+import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
+import com.clubber.ClubberServer.global.vo.ImageVO;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateRecruitResponse {
+    @NotNull
+    private String title;
+    @NotNull
+    private String content;
+
+    private List<String> imageUrl;
+
+    public static UpdateRecruitResponse of(Recruit recruit,List<ImageVO> images){
+        return UpdateRecruitResponse.builder()
+                .title(recruit.getTitle())
+                .content(recruit.getContent())
+                .images(images)
+                .updatedAt(recruit.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
@@ -18,12 +18,13 @@ public class UpdateRecruitResponse {
     @NotNull
     private String content;
 
-    private List<ImageVO> imageUrls;
+//    private List<ImageVO> imageUrls;
+    private List<String> imageUrls;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime updatedAt;
 
-    public static UpdateRecruitResponse of(Recruit recruit,List<ImageVO> imageUrls){
+    public static UpdateRecruitResponse of(Recruit recruit,List<String> imageUrls){
         return UpdateRecruitResponse.builder()
                 .title(recruit.getTitle())
                 .content(recruit.getContent())

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
@@ -2,30 +2,32 @@ package com.clubber.ClubberServer.domain.recruit.dto;
 
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
 import com.clubber.ClubberServer.global.vo.ImageVO;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateRecruitResponse {
     @NotNull
     private String title;
     @NotNull
     private String content;
 
-    private List<String> imageUrl;
+    private List<ImageVO> imageUrls;
 
-    public static UpdateRecruitResponse of(Recruit recruit,List<ImageVO> images){
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime updatedAt;
+
+    public static UpdateRecruitResponse of(Recruit recruit,List<ImageVO> imageUrls){
         return UpdateRecruitResponse.builder()
                 .title(recruit.getTitle())
                 .content(recruit.getContent())
-                .images(images)
+                .imageUrls(imageUrls)
                 .updatedAt(recruit.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitImageRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitImageRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 
 public interface RecruitImageRepository extends JpaRepository<RecruitImage,Long> {
     List<RecruitImage> findByRecruit(Recruit recruit);
+    List<RecruitImage> findByRecruitAndIsDeletedFalse(Recruit recruit);
+    List<RecruitImage> findByRecruitAndIsDeletedFalseOrderByOrderNumAsc(Recruit recruit);
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -29,8 +29,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.clubber.ClubberServer.global.jwt.JwtStatic.IMAGE_SERVER;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +61,8 @@ public class RecruitService {
 
         Page<GetOneRecruitResponse> recruitResponses = recruits.map(recruit -> {
             List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                    .filter(recruitImage -> !recruitImage.isDeleted())
+                    .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                     .map(RecruitImage::getImageUrl)
                     .collect(Collectors.toList());
             return GetOneRecruitResponse.of(recruit, imageUrls);
@@ -78,16 +85,23 @@ public class RecruitService {
         Recruit newRecruit=Recruit.of(club,requestDTO);
         recruitRepository.save(newRecruit);
 
+        AtomicLong order = new AtomicLong(1L);
+
         List<RecruitImage> savedImages = requestDTO.getImageKey().stream()
-                .map(imageUrl -> recruitImageRepository.save(
-                        RecruitImage.of(ImageVO.valueOf(imageUrl), newRecruit))
-                )
+                .map(imageUrl -> {
+                    RecruitImage recruitImage = recruitImageRepository.save(
+                            RecruitImage.of(ImageVO.valueOf(imageUrl), newRecruit)
+                    );
+                    recruitImage.updateOrderNum(order.getAndIncrement()); // orderNum 설정
+                    return recruitImage;
+                })
                 .collect(Collectors.toList());
+
 
         List<ImageVO> imageUrls = savedImages.stream()
+                .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                 .map(RecruitImage::getImageUrl)
                 .collect(Collectors.toList());
-
 
         return PostRecruitResponse.of(newRecruit,imageUrls);
     }
@@ -109,6 +123,8 @@ public class RecruitService {
         }
 
         List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                .filter(recruitImage -> !recruitImage.isDeleted())
+                .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                 .map(RecruitImage::getImageUrl)
                 .collect(Collectors.toList());
 
@@ -120,7 +136,6 @@ public class RecruitService {
     }
 
 
-
     @Transactional(readOnly = true)
     public PageResponse<GetOneRecruitResponse> getRecruitsByClubId(Long clubId,Pageable pageable){
         Club club=clubRepository.findById(clubId)
@@ -130,6 +145,8 @@ public class RecruitService {
 
         Page<GetOneRecruitResponse> recruitDto = recruits.map(recruit -> {
             List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                    .filter(recruitImage -> !recruitImage.isDeleted())
+                    .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                     .map(RecruitImage::getImageUrl)
                     .collect(Collectors.toList());
             return GetOneRecruitResponse.of(recruit, imageUrls);
@@ -164,6 +181,8 @@ public class RecruitService {
 
         Page<GetOneRecruitResponse> recruitDto = recruits.map(recruit -> {
             List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                    .filter(recruitImage -> !recruitImage.isDeleted())
+                    .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                     .map(RecruitImage::getImageUrl)
                     .collect(Collectors.toList());
             return GetOneRecruitResponse.of(recruit, imageUrls);
@@ -183,6 +202,8 @@ public class RecruitService {
         recruit.increaseTotalview();
 
         List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                .filter(recruitImage -> !recruitImage.isDeleted())
+                .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                 .map(RecruitImage::getImageUrl)
                 .collect(Collectors.toList());
 
@@ -204,8 +225,11 @@ public class RecruitService {
         }
 
         List<ImageVO> imageUrls = recruit.getRecruitImages().stream()
+                .filter(recruitImage -> !recruitImage.isDeleted())
+                .sorted(Comparator.comparing(RecruitImage::getOrderNum))
                 .map(RecruitImage::getImageUrl)
                 .collect(Collectors.toList());
+
 
         return GetOneRecruitResponse.of(recruit, imageUrls);
 
@@ -228,20 +252,42 @@ public class RecruitService {
 
         recruit.updateRecruitPage(requestPage.getTitle(), requestPage.getContent());
 
+        List<RecruitImage> recruitImages = recruit.getRecruitImages().stream() // 현재 해당 게시글의 모든 이미지 조회
+                .filter(recruitImage -> !recruitImage.isDeleted())
+                .collect(Collectors.toList());
 
-        List<RecruitImage> savedImages = requestPage.getCreatedImageKeys().stream()
-                .map(imageUrl -> recruitImageRepository.save(
-                        RecruitImage.of(ImageVO.valueOf(imageUrl), recruit))
+
+        recruitImages.stream()
+                .filter(recruitImage -> requestPage.getDeletedImageUrls().stream()
+                        .anyMatch(deleteImage -> deleteImage.substring(IMAGE_SERVER.length()).equals(recruitImage.getImageUrl().getImageUrl())))
+                .forEach(RecruitImage::updateStatus);
+
+
+        List<RecruitImage> newImages = requestPage.getNewImageKeys().stream() // 추가 요청 들어온것들은 recruitImage객체 생성하여 저장
+                .map(imageKey -> recruitImageRepository.save(
+                        RecruitImage.of(ImageVO.valueOf(imageKey), recruit))
                 )
                 .collect(Collectors.toList());
 
-        //deletedImageKeys처리하는 로직 구현
 
+        List<RecruitImage> revisedRecruitImages = recruitImageRepository.findByRecruitAndIsDeletedFalse(recruit);
 
-        List<ImageVO> imageUrls = savedImages.stream()
-                .map(RecruitImage::getImageUrl)
-                .collect(Collectors.toList());
+        AtomicLong order = new AtomicLong(1L);
 
-        return UpdateRecruitResponse.of(recruit,imageUrls);
+        List<String> finalImages = requestPage.getImages();
+        for (String image : finalImages){
+            if (image.startsWith(IMAGE_SERVER)){
+                revisedRecruitImages.stream()
+                        .filter(recruitImage-> recruitImage.getImageUrl().getImageUrl().equals(image.substring(IMAGE_SERVER.length())))
+                        .forEach(recruitImage -> recruitImage.updateOrderNum(order.getAndIncrement()));
+            }
+            else{
+                newImages.stream()
+                        .filter(recruitImage-> recruitImage.getImageUrl().getImageUrl().equals(image))
+                        .forEach(recruitImage -> recruitImage.updateOrderNum(order.getAndIncrement()));
+            }
+        }
+
+        return UpdateRecruitResponse.of(recruit,requestPage.getImages());
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -211,23 +211,37 @@ public class RecruitService {
 
     }
 
-//    @Transactional
-//    public UpdateRecruitResponse changeAdminRecruits(Long recruitId,UpdateRecruitRequest requestPage){
-//
-//        Long currentUserId = SecurityUtils.getCurrentUserId();
-//
-//        Admin admin = adminRepository.findById(currentUserId)
-//                .orElseThrow(() -> AdminNotFoundException.EXCEPTION);
-//
-//        Recruit recruit=recruitRepository.findRecruitWithImagesById(recruitId)
-//                .orElseThrow(()->RecruitNotFoundException.EXCEPTION);
-//
-//        if (recruit.getClub()!=admin.getClub()) {
-//            throw RecruitUnauthorized.EXCEPTION;
-//        }
-//
-//        recruit.updateRecruitPage(requestPage.getTitle(), requestPage.getContent());
-//
-//        return UpdateRecruitResponse.of(recruit,imageUrls);
-//    }
+    @Transactional
+    public UpdateRecruitResponse changeAdminRecruits(Long recruitId,UpdateRecruitRequest requestPage){
+
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+
+        Admin admin = adminRepository.findById(currentUserId)
+                .orElseThrow(() -> AdminNotFoundException.EXCEPTION);
+
+        Recruit recruit=recruitRepository.findRecruitWithImagesById(recruitId)
+                .orElseThrow(()->RecruitNotFoundException.EXCEPTION);
+
+        if (recruit.getClub()!=admin.getClub()) {
+            throw RecruitUnauthorized.EXCEPTION;
+        }
+
+        recruit.updateRecruitPage(requestPage.getTitle(), requestPage.getContent());
+
+
+        List<RecruitImage> savedImages = requestPage.getCreatedImageKeys().stream()
+                .map(imageUrl -> recruitImageRepository.save(
+                        RecruitImage.of(ImageVO.valueOf(imageUrl), recruit))
+                )
+                .collect(Collectors.toList());
+
+        //deletedImageKeys처리하는 로직 구현
+
+
+        List<ImageVO> imageUrls = savedImages.stream()
+                .map(RecruitImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        return UpdateRecruitResponse.of(recruit,imageUrls);
+    }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -204,4 +204,24 @@ public class RecruitService {
         return GetOneRecruitResponse.of(recruit, imageUrls);
 
     }
+
+//    @Transactional
+//    public UpdateRecruitResponse changeAdminRecruits(Long recruitId,UpdateRecruitRequest requestPage){
+//
+//        Long currentUserId = SecurityUtils.getCurrentUserId();
+//
+//        Admin admin = adminRepository.findById(currentUserId)
+//                .orElseThrow(() -> AdminNotFoundException.EXCEPTION);
+//
+//        Recruit recruit=recruitRepository.findRecruitWithImagesById(recruitId)
+//                .orElseThrow(()->RecruitNotFoundException.EXCEPTION);
+//
+//        if (recruit.getClub()!=admin.getClub()) {
+//            throw RecruitUnauthorized.EXCEPTION;
+//        }
+//
+//        recruit.updateRecruitPage(requestPage.getTitle(), requestPage.getContent());
+//
+//        return UpdateRecruitResponse.of(recruit,imageUrls);
+//    }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->

## Key Changes
- [ ] RecruitImage 필드값에 OrderNum 추가(관리자가 지정한 화면 출력 순서 저장하기 위함)
- [ ] 모집글 수정 api 구현
- [ ] 모집글 작성 api 수정 - recruitImage의 orderNum 값 설정 추가
- [ ] 개별 모집글 조회 api 수정 - recruitImage의 orderNum sorting해서 보내주는 것 추가 + 삭제된 이미지는 filtering
- [ ] 모든 모집글 조회 api 수정 - recruitImage의 orderNum sorting해서 보내주는 것 추가 + 삭제된 이미지는 filtering



## ETC 
* 모집글 수정 api - 프론트에서 받아오는 dto구조
   - private String title;
   - private String content;
   - private List<String> deletedImageUrls; // 삭제할 이미지 url들
   - private List<String> newImageKeys; // 새로 추가할 이미지 key들
   - private List<String> remainImageUrls; // 유지할 이미지 url들
   - private List<String> images; // 최종적으로 지정한 이미지 url+key들 (새로 추가된것과 기존의 것이 섞여있는 상태 + 화면에 출력할 순서대로 구성하여 보내줘야함)



* 백엔드에서의 처리
1) 해당 게시물의 기존 이미지를 모두 가져온다
2) 삭제한 이미지들을 삭제해준다
3) 새로 추가할 이미지들을 추가해준다
4) 관리자가 요청한 순서를 저장해준다. -> 순서가 저장되어야하기에 recruitImage에 OrderNum(Long) 추가

## 추후 수정필요한 내용들
orderNum을 설정해줄때 하나의 recruitImager객체당 한개의 update query가 발생하는데, 성능적으로 보완할 방법 찾아보기
관리자 - 모집글 전체 조회 page 제대로 처리되지 않는 것 같음