### PR TITLE
refactor : 동아리 모집글 수정 api 리펙토링 (#498)

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/adminRecruitController.java
@@ -23,7 +23,7 @@ public class adminRecruitController {
 
     @GetMapping("/admins/recruits")
     @Operation(summary = "동아리 계정의 모든 모집글 조회")
-    public PageResponse<GetOneRecruitResponse> getAllAdminRecruits(@PageableDefault(size = 5) Pageable pageable){
+    public PageResponse<GetOneRecruitInListResponse> getAllAdminRecruits(@PageableDefault(size = 5) Pageable pageable){
         return recruitService.getAllAdminRecruits(pageable);
     }
 

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/recruitController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/recruitController.java
@@ -41,7 +41,7 @@ public class recruitController {
     @GetMapping("/recruits")
     @DisableSwaggerSecurity
     @Operation(summary = "홍보 게시판에서 모든 모집글 조회")
-    public PageResponse<GetOneRecruitResponse> getAllRecruitsPage(@PageableDefault(size = 5) Pageable pageable){
+    public PageResponse<GetOneRecruitInListResponse> getAllRecruitsPage(@PageableDefault(size = 5) Pageable pageable){
         return recruitService.getAllRecruitsPage(pageable);
     }
 

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/GetOneRecruitInListResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/GetOneRecruitInListResponse.java
@@ -1,0 +1,39 @@
+package com.clubber.ClubberServer.domain.recruit.dto;
+
+import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
+import com.clubber.ClubberServer.global.vo.ImageVO;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetOneRecruitInListResponse {
+
+    private Long clubId;
+    private Long recruitId;
+    private String title;
+    private String content;
+    private ImageVO imageUrl;
+    private Long totalView;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+
+    public static GetOneRecruitInListResponse of(Recruit recruit,ImageVO imageUrl){
+        return GetOneRecruitInListResponse.builder()
+                .clubId(recruit.getClub().getId())
+                .recruitId(recruit.getId())
+                .title(recruit.getTitle())
+                .content(recruit.getContent())
+                .imageUrl(imageUrl)
+                .totalView(recruit.getTotalView())
+                .createdAt(recruit.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/UpdateRecruitResponse.java
@@ -18,7 +18,6 @@ public class UpdateRecruitResponse {
     @NotNull
     private String content;
 
-//    private List<ImageVO> imageUrls;
     private List<String> imageUrls;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitImageRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitImageRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface RecruitImageRepository extends JpaRepository<RecruitImage,Long> {
-    List<RecruitImage> findByRecruit(Recruit recruit);
     List<RecruitImage> findByRecruitAndIsDeletedFalse(Recruit recruit);
-    List<RecruitImage> findByRecruitAndIsDeletedFalseOrderByOrderNumAsc(Recruit recruit);
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
@@ -22,8 +22,7 @@ public interface RecruitRepository extends JpaRepository<Recruit,Long>{
 
     Page<Recruit> findByIsDeletedFalseAndClubOrderByIdDesc(@Param("club") Club club,Pageable pageable);
 
-    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false ORDER BY r.id DESC ")
-    Page<Recruit> findRecruits(Pageable pageable);
+    Page<Recruit> findByIsDeletedFalseOrderByIdDesc(Pageable pageable);
 
     Optional<Recruit> findRecruitById(@Param("recruitId") Long recruitId);
 

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
@@ -15,18 +15,17 @@ import java.util.Optional;
 
 public interface RecruitRepository extends JpaRepository<Recruit,Long>{
 
-    @Query("SELECT DISTINCT r FROM Recruit r LEFT JOIN r.recruitImages WHERE r.isDeleted = false ORDER BY r.id DESC")
-    Page<Recruit> findRecruitsWithImages(Pageable pageable);
-
-    @Query("SELECT DISTINCT r FROM Recruit r LEFT JOIN r.recruitImages WHERE r.club = :club AND r.isDeleted = false ORDER BY r.id DESC")
-    Page<Recruit> findRecruitsWithImagesByClub(@Param("club") Club club, Pageable pageable);
-
-    @Query("SELECT r FROM Recruit r LEFT JOIN FETCH r.recruitImages WHERE r.id = :recruitId AND r.isDeleted = false ORDER BY r.id DESC")
-    Optional<Recruit> findRecruitWithImagesById(@Param("recruitId") Long recruitId);
-
     @Query("SELECT COALESCE(MAX(id), 0) FROM Recruit")
     Long findMaxRecruitId();
 
     List<Recruit> findTop5ByOrderByIdDesc();
+
+    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false AND r.club =:club ORDER BY r.id DESC ")
+    Page<Recruit> findRecruitsByClub(@Param("club") Club club,Pageable pageable);
+
+    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false ORDER BY r.id DESC ")
+    Page<Recruit> findRecruits(Pageable pageable);
+
+    Optional<Recruit> findRecruitById(@Param("recruitId") Long recruitId);
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
@@ -20,9 +20,6 @@ public interface RecruitRepository extends JpaRepository<Recruit,Long>{
 
     List<Recruit> findTop5ByOrderByIdDesc();
 
-//    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false AND r.club =:club ORDER BY r.id DESC ")
-//    Page<Recruit> findRecruitsByClub(@Param("club") Club club,Pageable pageable);
-
     Page<Recruit> findByIsDeletedFalseAndClubOrderByIdDesc(@Param("club") Club club,Pageable pageable);
 
     @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false ORDER BY r.id DESC ")

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
@@ -20,8 +20,10 @@ public interface RecruitRepository extends JpaRepository<Recruit,Long>{
 
     List<Recruit> findTop5ByOrderByIdDesc();
 
-    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false AND r.club =:club ORDER BY r.id DESC ")
-    Page<Recruit> findRecruitsByClub(@Param("club") Club club,Pageable pageable);
+//    @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false AND r.club =:club ORDER BY r.id DESC ")
+//    Page<Recruit> findRecruitsByClub(@Param("club") Club club,Pageable pageable);
+
+    Page<Recruit> findByIsDeletedFalseAndClubOrderByIdDesc(@Param("club") Club club,Pageable pageable);
 
     @Query("SELECT r FROM Recruit r WHERE r.isDeleted = false ORDER BY r.id DESC ")
     Page<Recruit> findRecruits(Pageable pageable);

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -176,7 +176,7 @@ public class RecruitService {
 
     @Transactional(readOnly = true)
     public PageResponse<GetOneRecruitInListResponse> getAllRecruitsPage(Pageable pageable){
-        Page<Recruit> recruits = recruitRepository.findRecruits(pageable);
+        Page<Recruit> recruits = recruitRepository.findByIsDeletedFalseOrderByIdDesc(pageable);
 
         Page<GetOneRecruitInListResponse> recruitResponses = recruits.map(recruit -> {
             ImageVO imageUrl = recruit.getRecruitImages().stream()

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -57,7 +57,7 @@ public class RecruitService {
 
         Club club=admin.getClub();
 
-        Page<Recruit> recruits = recruitRepository.findRecruitsByClub(club,pageable);
+        Page<Recruit> recruits = recruitRepository.findByIsDeletedFalseAndClubOrderByIdDesc(club,pageable);
 
         Page<GetOneRecruitInListResponse> recruitResponses = recruits.map(recruit -> {
             ImageVO imageUrl = recruit.getRecruitImages().stream()
@@ -141,7 +141,7 @@ public class RecruitService {
         Club club=clubRepository.findById(clubId)
                 .orElseThrow(()-> ClubIdNotFoundException.EXCEPTION);
 
-        Page<Recruit> recruits = recruitRepository.findRecruitsByClub(club,pageable);
+        Page<Recruit> recruits = recruitRepository.findByIsDeletedFalseAndClubOrderByIdDesc(club,pageable);
 
         Page<GetOneRecruitResponse> recruitDto = recruits.map(recruit -> {
             List<ImageVO> imageUrls = recruit.getRecruitImages().stream()


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->

## Key Changes
- left join 제거
- recruit의 getRecruitImage()사용하여 이미지 가져오기
- recruitImageRepository에서 사용하지 않는 메서드 제거
- recruitRepository에서 left join 사용하던 메서드 전부 제거
- 모집글 목록 형태로 화면에서 호출하는 api -> 첫번째 이미지 하나만 보내주는 걸로 수정 -> GetOneRecruitInListResponse DTO 새로 구현
- 모집글 삭제 API : 기존- Recruit만 삭제, 해당 모집글에 속한 이미지들은 삭제 안시킴 -> 수정후- Recruit 삭제, 해당 모집글에 속한 이미지들도 soft delete 시킴
- 생각해보니 repository에서의 "r.isDeleted = false"는 Recruit의 삭제 여부 필터링에 사용되므로, recruitImage는 service에서 filter()적용해서 삭제되지 않은 이미지들을 필터링해줘야함

## ETC 
✔️ 프론트에서 반환받는 json형태 변하는게 있어서 (모집글 목록 형식으로 열람 - 일반회원 홈페이지에서 모집글 클릭시 호출되는 api, 관리자 나의 모집글 클릭시 호출되는 api, 개별 동아리 페이지에서 모집글 보러가기 클릭시 호출되는 api) 먼저 알려준후에 머지해야할듯

=> 목록형식으로 모집글 조회하는 경우 예시
<img width="827" alt="스크린샷 2024-11-16 오후 5 55 19" src="https://github.com/user-attachments/assets/b0814b47-5269-49f3-8cb9-7665788a4ee2">