### PR TITLE
feat : 숭실대 공식 단체 조회 api 구현 (#650)

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/club/controller/ClubController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/controller/ClubController.java
@@ -7,6 +7,7 @@ import com.clubber.ClubberServer.domain.club.dto.DepartmentSmallDto;
 import com.clubber.ClubberServer.domain.club.dto.GetClubByDivisionResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetClubPopularResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetClubResponse;
+import com.clubber.ClubberServer.domain.club.dto.GetOfficialClubGroupResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetSummaryClubGroupResponse;
 import com.clubber.ClubberServer.domain.club.service.ClubService;
 import com.clubber.ClubberServer.global.config.swagger.DisableSwaggerSecurity;
@@ -95,6 +96,13 @@ public class ClubController {
     @GetMapping("/summary")
     public List<GetSummaryClubGroupResponse> getOneViewClubs() {
         return clubService.getSummaryClubs();
+    }
+
+    @DisableSwaggerSecurity
+    @Operation(summary = "숭실대 공식 단체 조회")
+    @GetMapping("/official")
+    public GetOfficialClubGroupResponse getOfficialClubs() {
+        return clubService.getOfficialClubs();
     }
 
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/club/domain/ClubType.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/domain/ClubType.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public enum ClubType implements EnumMapperType {
     CENTER("중앙동아리"),
     SMALL("소모임"),
+    OFFICIAL("숭실대공식단체"),
     ETC("그 외");
 
     private final String title;

--- a/src/main/java/com/clubber/ClubberServer/domain/club/dto/GetOfficialClubGroupResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/dto/GetOfficialClubGroupResponse.java
@@ -1,0 +1,32 @@
+package com.clubber.ClubberServer.domain.club.dto;
+
+import com.clubber.ClubberServer.domain.club.domain.ClubType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetOfficialClubGroupResponse {
+
+
+    @Schema(description = "동아리 종류", example = "숭실대 공식 단체")
+    private final String clubType;
+
+    @Schema(description = "숭실대 공식 단체 목록")
+    private final List<GetOfficialClubResponse> clubs;
+
+    public static GetOfficialClubGroupResponse of(ClubType clubType,
+        List<GetOfficialClubResponse> clubs) {
+        return GetOfficialClubGroupResponse.builder()
+            .clubType(clubType.getTitle())
+            .clubs(clubs)
+            .build();
+    }
+}
+

--- a/src/main/java/com/clubber/ClubberServer/domain/club/dto/GetOfficialClubResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/dto/GetOfficialClubResponse.java
@@ -1,0 +1,41 @@
+package com.clubber.ClubberServer.domain.club.dto;
+
+import com.clubber.ClubberServer.domain.club.domain.Club;
+import com.clubber.ClubberServer.global.vo.image.ImageVO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetOfficialClubResponse {
+
+    @Schema(description = "정보 제공 동의 여부", example = "false")
+    private final boolean isAgreeToProvideInfo;
+
+    @Schema(description = "동아리 id", example = "1")
+    private final Long clubId;
+
+    @Schema(description = "동아리 대표 로고", example = "https://image.ssuclubber.com/club/image1")
+    private final ImageVO imageUrl;
+
+    @Schema(description = "동아리명", example = "클러버")
+    private final String clubName;
+
+    @Schema(description = "동아리 소개", example = "숭실대학교 동아리 정보 제공 웹서비스 클러버")
+    private final String introduction;
+
+    public static GetOfficialClubResponse from(Club club) {
+        return GetOfficialClubResponse.builder()
+            .isAgreeToProvideInfo(club.isAgreeToProvideInfo())
+            .clubId(club.getId())
+            .imageUrl(club.getImageUrl())
+            .clubName(club.getName())
+            .introduction(club.getIntroduction())
+            .build();
+    }
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/club/service/ClubService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/service/ClubService.java
@@ -17,6 +17,8 @@ import com.clubber.ClubberServer.domain.club.dto.GetClubResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetClubSearchResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetClubsByHashTagResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetClubsSearchResponse;
+import com.clubber.ClubberServer.domain.club.dto.GetOfficialClubGroupResponse;
+import com.clubber.ClubberServer.domain.club.dto.GetOfficialClubResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetSummaryClubGroupResponse;
 import com.clubber.ClubberServer.domain.club.dto.GetSummaryClubResponse;
 import com.clubber.ClubberServer.domain.club.exception.ClubIdNotFoundException;
@@ -179,6 +181,17 @@ public class ClubService {
             .map(clubGroup -> GetSummaryClubGroupResponse.of(clubGroup.getKey(),
                 clubGroup.getValue()))
             .collect(Collectors.toList());
+    }
+
+    // [숭실대 공식 단체]
+    public GetOfficialClubGroupResponse getOfficialClubs() {
+        List<Club> clubs = clubRepository.findByClubTypeAndIsDeletedFalse(ClubType.OFFICIAL);
+
+        List<GetOfficialClubResponse> clubList = clubs.stream()
+            .map(GetOfficialClubResponse::from)
+            .collect(Collectors.toList());
+
+        return GetOfficialClubGroupResponse.of(ClubType.OFFICIAL, clubList);
     }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->

## Key Changes
- [ ] 숭실대 공식 단체 조회 api 구현 -> 카드 형식으로 반환

## ETC 
