### PR TITLE
refactor : 모니터링 컨테이너 분리

### DIFF
--- a/docker-compose-monitory.yml
+++ b/docker-compose-monitory.yml
@@ -1,0 +1,37 @@
+services:
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - clubber
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SERVER_HTTP_PORT=4000
+    container_name: grafana
+    ports:
+      - "4000:4000"
+    #    volumes:
+    #      - ./grafana:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - clubber
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yaml
+    command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
+    networks:
+      - clubber

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -54,43 +54,6 @@ services:
     networks:
       - clubber
 
-#  prometheus:
-#    container_name: prometheus
-#    image: prom/prometheus:latest
-#    ports:
-#      - "9090:9090"
-#    volumes:
-#      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-#    extra_hosts:
-#      - "host.docker.internal:host-gateway"
-#    networks:
-#      - clubber
-#
-#  grafana:
-#    image: grafana/grafana:latest
-#    environment:
-#      - GF_SERVER_HTTP_PORT=4000
-#    container_name: grafana
-#    ports:
-#      - "4000:4000"
-#    #    volumes:
-#    #      - ./grafana:/var/lib/grafana
-#    depends_on:
-#      - prometheus
-#    networks:
-#      - clubber
-#
-#  loki:
-#    container_name: loki
-#    image: grafana/loki:latest
-#    ports:
-#      - "3100:3100"
-#    volumes:
-#      - ./loki-config.yml:/etc/loki/loki-config.yaml
-#    command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
-#    networks:
-#      - clubber
-
   promtail:
     container_name: promtail
     image: grafana/promtail:latest

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -54,42 +54,42 @@ services:
     networks:
       - clubber
 
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus:latest
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - clubber
-
-  grafana:
-    image: grafana/grafana:latest
-    environment:
-      - GF_SERVER_HTTP_PORT=4000
-    container_name: grafana
-    ports:
-      - "4000:4000"
-    #    volumes:
-    #      - ./grafana:/var/lib/grafana
-    depends_on:
-      - prometheus
-    networks:
-      - clubber
-
-  loki:
-    container_name: loki
-    image: grafana/loki:latest
-    ports:
-      - "3100:3100"
-    volumes:
-      - ./loki-config.yml:/etc/loki/loki-config.yaml
-    command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
-    networks:
-      - clubber
+#  prometheus:
+#    container_name: prometheus
+#    image: prom/prometheus:latest
+#    ports:
+#      - "9090:9090"
+#    volumes:
+#      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+#    extra_hosts:
+#      - "host.docker.internal:host-gateway"
+#    networks:
+#      - clubber
+#
+#  grafana:
+#    image: grafana/grafana:latest
+#    environment:
+#      - GF_SERVER_HTTP_PORT=4000
+#    container_name: grafana
+#    ports:
+#      - "4000:4000"
+#    #    volumes:
+#    #      - ./grafana:/var/lib/grafana
+#    depends_on:
+#      - prometheus
+#    networks:
+#      - clubber
+#
+#  loki:
+#    container_name: loki
+#    image: grafana/loki:latest
+#    ports:
+#      - "3100:3100"
+#    volumes:
+#      - ./loki-config.yml:/etc/loki/loki-config.yaml
+#    command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
+#    networks:
+#      - clubber
 
   promtail:
     container_name: promtail


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
#678

## Key Changes
- [x] 별도 EC2 모니터링 호스트에서 Grafana, Loki, Prometheus 컨테이너 구동 
- [x] Promtail은 모니터링 서버로 로그 전송 
- [x] Prometheus는 운영서버 메트릭 정보 수집 
- [x] 개발 서버는 분리 안하고 그대로 운영 

## ETC 
