### PR TITLE
test : 테스트 코드 given fixutre 셋업 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 
     //java mail sender
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //fixture monkey
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.10")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clubber/ClubberServer/domain/admin/domain/Contact.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/admin/domain/Contact.java
@@ -2,10 +2,15 @@ package com.clubber.ClubberServer.domain.admin.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Contact {
     @Column(name = "contact_instagram")
     private String instagram;

--- a/src/main/java/com/clubber/ClubberServer/domain/club/repository/ClubInfoRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/club/repository/ClubInfoRepository.java
@@ -1,0 +1,7 @@
+package com.clubber.ClubberServer.domain.club.repository;
+
+import com.clubber.ClubberServer.domain.club.domain.ClubInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubInfoRepository extends JpaRepository<ClubInfo, Long> {
+}

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -21,7 +21,6 @@ import com.clubber.ClubberServer.global.config.security.AuthDetails;
 import com.clubber.ClubberServer.global.config.security.SecurityUtils;
 import com.clubber.ClubberServer.integration.util.WithMockCustomUser;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
-import com.navercorp.fixturemonkey.FixtureMonkey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +79,7 @@ public class AdminAccountServiceTest {
     @Test
     void adminGetProfile() {
         //given
-        Admin admin = AdminFixture.getDefaultAdminBuilder().build();
+        Admin admin = AdminFixture.aAdmin().build();
         Admin saved = adminRepository.save(admin);
         createSecurityContext(saved.getId());
 
@@ -103,7 +102,7 @@ public class AdminAccountServiceTest {
         final String oldPassword = "oldPassword";
         final String newPassword = "newPassword";
 
-        Admin admin = AdminFixture.getDefaultAdminBuilder()
+        Admin admin = AdminFixture.aAdmin()
                 .password(encoder.encode(oldPassword))
                 .build();
 
@@ -125,7 +124,7 @@ public class AdminAccountServiceTest {
     public void updateAdminWithSameWithPreviousPasswordTest() {
         //given
         final String oldPassword = "oldPassword";
-        Admin admin = AdminFixture.getDefaultAdminBuilder()
+        Admin admin = AdminFixture.aAdmin()
                 .password(encoder.encode(oldPassword))
                 .build();
 
@@ -146,7 +145,7 @@ public class AdminAccountServiceTest {
         String validPassword = "password";
         String invalidPassword = "invalidPassword";
 
-        Admin admin = AdminFixture.getDefaultAdminBuilder()
+        Admin admin = AdminFixture.aAdmin()
                 .password(encoder.encode(validPassword))
                 .build();
         Long id = adminRepository.save(admin).getId();
@@ -163,7 +162,7 @@ public class AdminAccountServiceTest {
     @Test
     void withDrawAdmin() {
         //given
-        Admin admin = AdminFixture.getDefaultAdminBuilder().build();
+        Admin admin = AdminFixture.aAdmin().build();
         Long id = adminRepository.save(admin).getId();
         createSecurityContext(id);
 
@@ -259,7 +258,7 @@ public class AdminAccountServiceTest {
         final String existUsername = "username";
         final String nonExistUsername = "new username";
 
-        Admin admin = AdminFixture.getDefaultAdminBuilder()
+        Admin admin = AdminFixture.aAdmin()
                 .username(existUsername)
                 .build();
         adminRepository.save(admin);
@@ -276,7 +275,7 @@ public class AdminAccountServiceTest {
     void getAdminExistUsernameCheckDuplicateTest(){
         //given
         final String existUsername = "username";
-        Admin admin = AdminFixture.getDefaultAdminBuilder()
+        Admin admin = AdminFixture.aAdmin()
                 .username(existUsername)
                 .build();
 

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -153,19 +153,19 @@ public class AdminAccountServiceTest {
                 .isInstanceOf(AdminInvalidCurrentPasswordException.class);
     }
 
-    @DisplayName("관리자 회원탈퇴를 수행하면 계정 상태가 비활성화 된다.")
     @Test
-    void withDrawAdmin() {
+    void 관리자_회원탈퇴후_상태_비활성화() {
         //given
         Admin admin = AdminFixture.aAdmin().build();
-        createSecurityContext(adminRepository.save(admin));
+        Admin saved = adminRepository.save(admin);
+        createSecurityContext(saved);
 
+        //when
         adminAccountService.withDraw();
-        Admin adminAfterWithdraw = adminRepository.findById(SecurityUtils.getCurrentUserId()).get();
 
-        assertAll(
-                () -> assertThat(adminAfterWithdraw.getAccountState()).isEqualTo(AccountState.INACTIVE)
-        );
+        //then
+        Admin adminAfterWithdraw = adminRepository.findById(saved.getId()).get();
+        assertThat(adminAfterWithdraw.getAccountState()).isEqualTo(AccountState.INACTIVE);
     }
 
     /**

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -21,6 +21,7 @@ import com.clubber.ClubberServer.global.config.security.AuthDetails;
 import com.clubber.ClubberServer.global.config.security.SecurityUtils;
 import com.clubber.ClubberServer.integration.util.WithMockCustomUser;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
+import com.navercorp.fixturemonkey.FixtureMonkey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -270,9 +271,9 @@ public class AdminAccountServiceTest {
         assertThat(response.isAvailable()).isEqualTo(true);
     }
 
-    @DisplayName("기존에 있는 동아리 관리자 아이디 중복 확인시 false 반환")
+    @DisplayName("기존에 있는 동아리 관리자 아이디 중복 확인시 회원가입 가능 여부 false 반환")
     @Test
-    void getAdminExistUsernameCheckDuplicate(){
+    void getAdminExistUsernameCheckDuplicateTest(){
         //given
         final String existUsername = "username";
         Admin admin = AdminFixture.getDefaultAdminBuilder()

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -245,12 +245,11 @@ public class AdminAccountServiceTest {
 //        );
 //    }
 
-    @DisplayName("기존에 없는 동아리 관리자 아이디 중복 확인시 true 반환")
     @Test
-    void getAdminNewUsernameCheckDuplicate() {
+    void 기존에_존재하지_않는_동아리_관리자_아이디_중복확인() {
         //given
-        final String existUsername = "username";
-        final String nonExistUsername = "new username";
+        final String existUsername = "clubber123";
+        final String nonExistUsername = "newclubber123";
 
         Admin admin = AdminFixture.aAdmin()
                 .username(existUsername)
@@ -264,15 +263,13 @@ public class AdminAccountServiceTest {
         assertThat(response.isAvailable()).isEqualTo(true);
     }
 
-    @DisplayName("기존에 있는 동아리 관리자 아이디 중복 확인시 회원가입 가능 여부 false 반환")
     @Test
-    void getAdminExistUsernameCheckDuplicateTest() {
+    void 기존에_존재하는_동아리_관리자_아이디_중복확인() {
         //given
-        final String existUsername = "username";
+        final String existUsername = "clubber123";
         Admin admin = AdminFixture.aAdmin()
                 .username(existUsername)
                 .build();
-
         adminRepository.save(admin);
 
         //when

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -23,7 +23,10 @@ import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AdminAccountServiceTest extends ServiceTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
+public class AdminAccountServiceTest {
 
     @Autowired
     private AdminAccountService adminAccountService;

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -107,7 +107,7 @@ public class AdminAccountServiceTest {
                 .build();
         createSecurityContext(adminRepository.save(admin));
 
-        UpdateAdminsPasswordRequest request = AdminFixture.마이페이지_비밀번호_변경_요청(oldPassword, newPassword);
+        UpdateAdminsPasswordRequest request = AdminFixture.a_마이페이지_비밀번호_변경_요청().sample();
 
         //when
         adminAccountService.updateAdminsPassword(request);
@@ -126,7 +126,9 @@ public class AdminAccountServiceTest {
                 .build();
         createSecurityContext(adminRepository.save(admin));
 
-        UpdateAdminsPasswordRequest request = AdminFixture.마이페이지_비밀번호_변경_요청(oldPassword, oldPassword);
+        UpdateAdminsPasswordRequest request = AdminFixture.a_마이페이지_비밀번호_변경_요청()
+                .set("newPassword", oldPassword)
+                .sample();
 
         //when & Then
         assertThatThrownBy(() -> adminAccountService.updateAdminsPassword(request))

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -1,12 +1,10 @@
 package com.clubber.ClubberServer.integration.domain.admin.service;
 
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
-import com.clubber.ClubberServer.domain.admin.domain.Contact;
 import com.clubber.ClubberServer.domain.admin.domain.PendingAdminInfo;
 import com.clubber.ClubberServer.domain.admin.dto.*;
 import com.clubber.ClubberServer.domain.admin.exception.AdminEqualsPreviousPasswordExcpetion;
 import com.clubber.ClubberServer.domain.admin.exception.AdminInvalidCurrentPasswordException;
-import com.clubber.ClubberServer.domain.admin.exception.AdminLoginFailedException;
 import com.clubber.ClubberServer.domain.admin.repository.AdminRepository;
 import com.clubber.ClubberServer.domain.admin.repository.PendingAdminInfoRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminAccountService;
@@ -22,7 +20,6 @@ import com.clubber.ClubberServer.global.config.security.SecurityUtils;
 import com.clubber.ClubberServer.integration.util.ServiceTest;
 import com.clubber.ClubberServer.integration.util.WithMockCustomUser;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +31,8 @@ import java.util.Optional;
 import static com.clubber.ClubberServer.domain.club.domain.ClubType.GENERAL;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.integration.util.fixture.AdminFixture.VALID_UPDATE_PASSWORD_REQUEST;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AdminAccountServiceTest extends ServiceTest {

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAccountServiceTest.java
@@ -118,13 +118,12 @@ public class AdminAccountServiceTest {
     }
 
     @Test
-    public void 비밀번호_변경_기존_비밀번호_동일_에러() {
+    public void 관리자_비밀번호_변경_기존_비밀번호_동일_에러() {
         //given
         final String oldPassword = "oldPassword";
         Admin admin = AdminFixture.aAdmin()
                 .password(encoder.encode(oldPassword))
                 .build();
-
         createSecurityContext(adminRepository.save(admin));
 
         UpdateAdminsPasswordRequest request = AdminFixture.마이페이지_비밀번호_변경_요청(oldPassword, oldPassword);
@@ -145,7 +144,9 @@ public class AdminAccountServiceTest {
                 .build();
         createSecurityContext(adminRepository.save(admin));
 
-        UpdateAdminsPasswordRequest request = AdminFixture.마이페이지_비밀번호_변경_요청(invalidPassword, invalidPassword);
+        UpdateAdminsPasswordRequest request = AdminFixture.a_마이페이지_비밀번호_변경_요청()
+                .set("oldPassword", invalidPassword)
+                .sample();
 
         //when & Then
         assertThatThrownBy(() -> adminAccountService.updateAdminsPassword(request))
@@ -246,7 +247,7 @@ public class AdminAccountServiceTest {
 
     @DisplayName("기존에 없는 동아리 관리자 아이디 중복 확인시 true 반환")
     @Test
-    void getAdminNewUsernameCheckDuplicate(){
+    void getAdminNewUsernameCheckDuplicate() {
         //given
         final String existUsername = "username";
         final String nonExistUsername = "new username";
@@ -265,7 +266,7 @@ public class AdminAccountServiceTest {
 
     @DisplayName("기존에 있는 동아리 관리자 아이디 중복 확인시 회원가입 가능 여부 false 반환")
     @Test
-    void getAdminExistUsernameCheckDuplicateTest(){
+    void getAdminExistUsernameCheckDuplicateTest() {
         //given
         final String existUsername = "username";
         Admin admin = AdminFixture.aAdmin()

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminAuthServiceTest.java
@@ -1,20 +1,23 @@
 package com.clubber.ClubberServer.integration.domain.admin.service;
 
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
-import com.clubber.ClubberServer.domain.admin.dto.CreateAdminsLoginResponse;
+import com.clubber.ClubberServer.domain.admin.dto.CreateAdminsLoginRequest;
 import com.clubber.ClubberServer.domain.admin.repository.AdminRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminAuthService;
-import com.clubber.ClubberServer.integration.util.ServiceTest;
-import org.junit.jupiter.api.DisplayName;
+import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
-import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
-import static com.clubber.ClubberServer.integration.util.fixture.AdminFixture.VALID_ADMIN_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
-public class AdminAuthServiceTest extends ServiceTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
+public class AdminAuthServiceTest {
 
     @Autowired
     private AdminAuthService adminAuthService;
@@ -22,17 +25,27 @@ public class AdminAuthServiceTest extends ServiceTest {
     @Autowired
     private AdminRepository adminRepository;
 
-    @DisplayName("관리자 로그인을 수행한다")
-    @Test
-    void adminLogin() {
-        CreateAdminsLoginResponse createAdminLoginReponse = adminAuthService.createAdminsLogin(
-                VALID_ADMIN_REQUEST);
-        Admin admin = adminRepository.findAdminByIdAndAccountState(
-                createAdminLoginReponse.getAdminId(), ACTIVE).get();
+    @Autowired
+    private PasswordEncoder encoder;
 
-        assertAll(
-                () -> assertThat(admin).isNotNull(),
-                () -> assertThat(admin.getUsername()).isEqualTo(VALID_ADMIN_REQUEST.getUsername())
-        );
+    @Test
+    void 관리자_로그인_성공() {
+        //given
+        final String username = "clubber123";
+        final String password = "password";
+        Admin admin = AdminFixture.aAdmin()
+                .username(username)
+                .password(encoder.encode(password))
+                .build();
+        adminRepository.save(admin);
+
+        CreateAdminsLoginRequest request = AdminFixture.a_관리자_로그인_요청()
+                .set("username", username)
+                .set("password", password)
+                .sample();
+
+        //when & then
+        assertThatCode(() -> adminAuthService.createAdminsLogin(request))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminClubServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminClubServiceTest.java
@@ -1,78 +1,131 @@
 package com.clubber.ClubberServer.integration.domain.admin.service;
 
-import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
-import static com.clubber.ClubberServer.integration.util.fixture.AdminFixture.IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST;
-import static com.clubber.ClubberServer.integration.util.fixture.AdminFixture.VALID_UPDATE_CLUB_PAGE_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateClubPageRequest;
+import com.clubber.ClubberServer.domain.admin.repository.AdminRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminClubService;
 import com.clubber.ClubberServer.domain.admin.service.AdminReadService;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.club.domain.ClubInfo;
+import com.clubber.ClubberServer.domain.club.repository.ClubInfoRepository;
 import com.clubber.ClubberServer.domain.club.repository.ClubRepository;
-import com.clubber.ClubberServer.integration.util.ServiceTest;
+import com.clubber.ClubberServer.global.config.security.AuthDetails;
 import com.clubber.ClubberServer.integration.util.WithMockCustomUser;
+import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
+import com.clubber.ClubberServer.integration.util.fixture.ClubFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
-public class AdminClubServiceTest extends ServiceTest {
+import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
+import static com.clubber.ClubberServer.integration.util.fixture.AdminFixture.IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-	@Autowired
-	private AdminClubService adminClubService;
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
+public class AdminClubServiceTest {
 
-	@Autowired
-	private AdminReadService adminReadService;
+    @Autowired
+    private AdminClubService adminClubService;
 
-	@Autowired
-	private ClubRepository clubRepository;
+    @Autowired
+    private AdminReadService adminReadService;
 
-	@DisplayName("관리자의 동아리 페이지 정보 수정을 수행한다")
-	@WithMockCustomUser
-	@Test
-	void updateAdminsPage() {
-		//given & when
-		adminClubService.updateAdminsPage(VALID_UPDATE_CLUB_PAGE_REQUEST);
-		Admin admin = adminReadService.getCurrentAdmin();
-		Club club = clubRepository.findById(admin.getClub().getId()).get();
-		ClubInfo clubInfo = club.getClubInfo();
+    @Autowired
+    private ClubRepository clubRepository;
 
-		//then
-		assertAll(
-			() -> assertThat(club).isNotNull(),
-			() -> assertThat(club.getImageUrl().getImageUrl()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getImageKey()),
-			() -> assertThat(club.getIntroduction()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getIntroduction()),
-			() -> assertThat(clubInfo.getInstagram()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getInstagram()),
-			() -> assertThat(clubInfo.getActivity()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getActivity()),
-			() -> assertThat(clubInfo.getLeader()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getLeader()),
-			() -> assertThat(clubInfo.getRoom()).isEqualTo(
-				VALID_UPDATE_CLUB_PAGE_REQUEST.getRoom())
-		);
-	}
+    @Autowired
+    private ClubInfoRepository clubInfoRepository;
 
-	@DisplayName("이미지 서버 url을 포함한 imagekey 수정요청에는 imageKey만 반영된다")
-	@WithMockCustomUser
-	@Test
-	void updateAdminsPageWithImageServerURL() {
-		adminClubService.updateAdminsPage(IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST);
+    @Autowired
+    private AdminRepository adminRepository;
 
-		Admin admin = adminReadService.getCurrentAdmin();
-		Club club = clubRepository.findById(admin.getClub().getId()).get();
+    private void createSecurityContext(Admin admin) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-		assertAll(
-			() -> assertThat(club).isNotNull(),
-			() -> assertThat(club.getImageUrl()).asString()
-				.doesNotStartWith(IMAGE_SERVER),
-			() -> assertThat(club.getImageUrl().getImageUrl()).isEqualTo(
-				IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST.getImageKey()
-					.substring(IMAGE_SERVER.length()))
-		);
-	}
+        AuthDetails adminDetails = new AuthDetails(admin.getId().toString(), "ADMIN");
+        UsernamePasswordAuthenticationToken adminToken = new UsernamePasswordAuthenticationToken(
+                adminDetails, "user", adminDetails.getAuthorities());
+        context.setAuthentication(adminToken);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @DisplayName("관리자의 동아리 페이지 정보 수정을 수행한다")
+    @Test
+    void 관리자_동아리_페이지_정보_수정() {
+        //given
+        ClubInfo clubInfo = clubInfoRepository.save(ClubFixture.aClubInfo().build());
+        Club club = clubRepository.save(
+                ClubFixture.aClub()
+                        .clubInfo(clubInfo)
+                        .build()
+        );
+
+        Admin admin = adminRepository.save(
+                AdminFixture.aAdmin()
+                        .club(club)
+                        .build()
+        );
+        createSecurityContext(admin);
+
+        final String imageKey = "/prod/clubber/newKey";
+        final String introduction = "클러버 소개 새버전";
+        final String instagram = "@new_clubber_ssu";
+        final String youtube = "new_clubber_youtube";
+        final String activity = "새로운_활동_소개";
+        final String leader = "클러버_새_회장님";
+        final Long room = 101L;
+
+        UpdateClubPageRequest request = ClubFixture.a_관리자_동아리_페이지_수정_요청()
+                .set("imageKey", imageKey)
+                .set("introduction", introduction)
+                .set("instagram", instagram)
+                .set("youtube", youtube)
+                .set("activity", activity)
+                .set("leader", leader)
+                .set("room", room).sample();
+
+        //when
+        adminClubService.updateAdminsPage(request);
+
+        Club updatedClub = clubRepository.findById(club.getId()).get();
+        ClubInfo updatedClubInfo = updatedClub.getClubInfo();
+
+        //then
+        assertAll(
+                () -> assertThat(updatedClub.getImageUrl().getImageUrl()).isEqualTo(imageKey),
+                () -> assertThat(updatedClub.getIntroduction()).isEqualTo(introduction),
+                () -> assertThat(updatedClubInfo.getInstagram()).isEqualTo(instagram),
+                () -> assertThat(updatedClubInfo.getActivity()).isEqualTo(activity),
+                () -> assertThat(updatedClubInfo.getLeader()).isEqualTo(leader),
+                () -> assertThat(updatedClubInfo.getRoom()).isEqualTo(room)
+        );
+    }
+
+    @DisplayName("이미지 서버 url을 포함한 imagekey 수정요청에는 imageKey만 반영된다")
+    @WithMockCustomUser
+    @Test
+    void updateAdminsPageWithImageServerURL() {
+        adminClubService.updateAdminsPage(IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST);
+
+        Admin admin = adminReadService.getCurrentAdmin();
+        Club club = clubRepository.findById(admin.getClub().getId()).get();
+
+        assertAll(
+                () -> assertThat(club).isNotNull(),
+                () -> assertThat(club.getImageUrl()).asString()
+                        .doesNotStartWith(IMAGE_SERVER),
+                () -> assertThat(club.getImageUrl().getImageUrl()).isEqualTo(
+                        IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST.getImageKey()
+                                .substring(IMAGE_SERVER.length()))
+        );
+    }
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
@@ -24,15 +24,17 @@ public class AdminEmailAuthServiceTest extends ServiceTest {
     @Autowired
     private AdminEmailAuthService adminEmailAuthService;
 
-    @DisplayName("관리자 비밀번호 찾기 인증번호 검증을 수행한다")
+    @DisplayName("관리자 비밀번호 찾기 인증번호 검증을 성공한다.")
     @Test
     void validateAdminPasswordFindAuth() {
         //given
-        final String email = "test@gmail.com";
+        final String username = "clubber";
         final Integer authCode = 123456;
-        AdminPasswordFindAuth adminPasswordFindAuth = AdminFixture.비밀번호_찾기_인증(email, authCode);
+
+        AdminPasswordFindAuth adminPasswordFindAuth = AdminFixture.비밀번호_찾기_인증(username, authCode);
         adminPasswordFindAuthRepository.save(adminPasswordFindAuth);
-        UpdateAdminPasswordFindAuthVerifyRequest request = AdminFixture.비밀번호찾기_인증번호_검증요청(email, authCode);
+
+        UpdateAdminPasswordFindAuthVerifyRequest request = AdminFixture.비밀번호_찾기_인증_요청(username, authCode);
 
         //when & then
         Assertions.assertThatCode(() -> adminEmailAuthService.updateAdminPasswordFindAuthVerify(request))

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
@@ -2,10 +2,13 @@ package com.clubber.ClubberServer.integration.domain.admin.service;
 
 import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
+import com.clubber.ClubberServer.domain.admin.domain.AdminUsernameFindAuth;
 import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthVerifyRequest;
+import com.clubber.ClubberServer.domain.admin.dto.GetAdminUsernameFindRequest;
 import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVerifyRequest;
 import com.clubber.ClubberServer.domain.admin.repository.AdminPasswordFindAuthRepository;
 import com.clubber.ClubberServer.domain.admin.repository.AdminSignupAuthRepository;
+import com.clubber.ClubberServer.domain.admin.repository.AdminUsernameFindAuthRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminEmailAuthService;
 import com.clubber.ClubberServer.integration.util.fixture.AdminEmailAuthFixture;
 import org.assertj.core.api.Assertions;
@@ -22,6 +25,9 @@ public class AdminEmailAuthServiceTest {
 
     @Autowired
     private AdminSignupAuthRepository adminSignupAuthRepository;
+
+    @Autowired
+    private AdminUsernameFindAuthRepository adminUsernameFindAuthRepository;
 
     @Autowired
     private AdminPasswordFindAuthRepository adminPasswordFindAuthRepository;
@@ -45,6 +51,26 @@ public class AdminEmailAuthServiceTest {
 
         //when & then
         Assertions.assertThatCode(() -> adminEmailAuthService.updateAdminPasswordFindAuthVerify(request))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 동아리_아이디_찾기_인증번호_검증() {
+        //given
+        final Long clubId = 1L;
+        final Integer authCode = 123456;
+        final String email = "ssuclubber@gmail.com";
+
+        AdminUsernameFindAuth adminUsernameFindAuth = AdminEmailAuthFixture.aAdminUsernameFindAuth()
+                .clubId(clubId)
+                .authCode(authCode)
+                .build();
+        adminUsernameFindAuthRepository.save(adminUsernameFindAuth);
+
+        GetAdminUsernameFindRequest request = AdminEmailAuthFixture.아이디_찾기_인증_요청(clubId, email, authCode);
+
+        //when & then
+        Assertions.assertThatCode(() -> adminEmailAuthService.createAdminUsernameFindAuth(request.getClubId(), request.getAuthCode()))
                 .doesNotThrowAnyException();
     }
 

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
@@ -7,17 +7,24 @@ import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVer
 import com.clubber.ClubberServer.domain.admin.repository.AdminPasswordFindAuthRepository;
 import com.clubber.ClubberServer.domain.admin.repository.AdminSignupAuthRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminEmailAuthService;
-import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
+import com.clubber.ClubberServer.integration.util.fixture.AdminEmailAuthFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
 public class AdminEmailAuthServiceTest {
-    @Autowired
-    private AdminPasswordFindAuthRepository adminPasswordFindAuthRepository;
 
     @Autowired
     private AdminSignupAuthRepository adminSignupAuthRepository;
+
+    @Autowired
+    private AdminPasswordFindAuthRepository adminPasswordFindAuthRepository;
 
     @Autowired
     private AdminEmailAuthService adminEmailAuthService;
@@ -28,10 +35,13 @@ public class AdminEmailAuthServiceTest {
         final String username = "clubber";
         final Integer authCode = 123456;
 
-        AdminPasswordFindAuth adminPasswordFindAuth = AdminFixture.비밀번호_찾기_인증(username, authCode);
+        AdminPasswordFindAuth adminPasswordFindAuth = AdminEmailAuthFixture.aAdminPasswordFindAuth()
+                .username(username)
+                .authCode(authCode)
+                .build();
         adminPasswordFindAuthRepository.save(adminPasswordFindAuth);
 
-        UpdateAdminPasswordFindAuthVerifyRequest request = AdminFixture.비밀번호_찾기_인증_요청(username, authCode);
+        UpdateAdminPasswordFindAuthVerifyRequest request = AdminEmailAuthFixture.비밀번호_찾기_인증_요청(username, authCode);
 
         //when & then
         Assertions.assertThatCode(() -> adminEmailAuthService.updateAdminPasswordFindAuthVerify(request))
@@ -41,12 +51,18 @@ public class AdminEmailAuthServiceTest {
     @Test
     void 동아리_관리자_회원가입_인증번호_검증() {
         //given
-        final String clubName = "club";
-        final String email = "test@gmail.com";
+        final String clubName = "clubber";
+        final String email = "ssuclubber@gmail.com";
         final Integer authCode = 123456;
-        AdminSignupAuth adminSignupAuth = AdminFixture.회원가입_이메일_인증(clubName, email, authCode);
+
+        AdminSignupAuth adminSignupAuth = AdminEmailAuthFixture.aAdminSignupAuth()
+                .clubName(clubName)
+                .email(email)
+                .authCode(authCode)
+                .build();
         adminSignupAuthRepository.save(adminSignupAuth);
-        CreateAdminSignupAuthVerifyRequest request = AdminFixture.회원가입_이메일_인증_요청(clubName, email, authCode);
+
+        CreateAdminSignupAuthVerifyRequest request = AdminEmailAuthFixture.회원가입_이메일_인증_요청(clubName, email, authCode);
 
         //when & then
         Assertions.assertThatCode(() -> adminEmailAuthService.updateVerifyAdminSignupAuth(request))

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
@@ -2,19 +2,17 @@ package com.clubber.ClubberServer.integration.domain.admin.service;
 
 import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
-import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVerifyRequest;
 import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthVerifyRequest;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVerifyRequest;
 import com.clubber.ClubberServer.domain.admin.repository.AdminPasswordFindAuthRepository;
 import com.clubber.ClubberServer.domain.admin.repository.AdminSignupAuthRepository;
 import com.clubber.ClubberServer.domain.admin.service.AdminEmailAuthService;
-import com.clubber.ClubberServer.integration.util.ServiceTest;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class AdminEmailAuthServiceTest extends ServiceTest {
+public class AdminEmailAuthServiceTest {
     @Autowired
     private AdminPasswordFindAuthRepository adminPasswordFindAuthRepository;
 
@@ -24,9 +22,8 @@ public class AdminEmailAuthServiceTest extends ServiceTest {
     @Autowired
     private AdminEmailAuthService adminEmailAuthService;
 
-    @DisplayName("관리자 비밀번호 찾기 인증번호 검증을 성공한다.")
     @Test
-    void validateAdminPasswordFindAuth() {
+    void 동아리_관리자_비밀번호_찾기_인증번호_검증() {
         //given
         final String username = "clubber";
         final Integer authCode = 123456;
@@ -41,9 +38,8 @@ public class AdminEmailAuthServiceTest extends ServiceTest {
                 .doesNotThrowAnyException();
     }
 
-    @DisplayName("관리자 회원가입 인증번호 검증을 수행한다")
     @Test
-    void validateAdminSignupAuthVerify() {
+    void 동아리_관리자_회원가입_인증번호_검증() {
         //given
         final String clubName = "club";
         final String email = "test@gmail.com";

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/admin/service/AdminEmailAuthServiceTest.java
@@ -43,11 +43,12 @@ public class AdminEmailAuthServiceTest extends ServiceTest {
     @Test
     void validateAdminSignupAuthVerify() {
         //given
+        final String clubName = "club";
         final String email = "test@gmail.com";
         final Integer authCode = 123456;
-        AdminSignupAuth adminSignupAuth = AdminFixture.회원가입_이메일_인증(email, authCode);
+        AdminSignupAuth adminSignupAuth = AdminFixture.회원가입_이메일_인증(clubName, email, authCode);
         adminSignupAuthRepository.save(adminSignupAuth);
-        CreateAdminSignupAuthVerifyRequest request = AdminFixture.회원가입_이메일_인증_요청(email, authCode);
+        CreateAdminSignupAuthVerifyRequest request = AdminFixture.회원가입_이메일_인증_요청(clubName, email, authCode);
 
         //when & then
         Assertions.assertThatCode(() -> adminEmailAuthService.updateVerifyAdminSignupAuth(request))

--- a/src/test/java/com/clubber/ClubberServer/integration/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/domain/review/service/ReviewServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.clubber.ClubberServer.domain.review.domain.ApprovedStatus;
 import com.clubber.ClubberServer.domain.review.domain.Review;
+import com.clubber.ClubberServer.domain.review.dto.CreateClubReviewRequest;
 import com.clubber.ClubberServer.domain.review.dto.CreateClubReviewResponse;
 import com.clubber.ClubberServer.domain.review.exception.UserAlreadyReviewedException;
 import com.clubber.ClubberServer.domain.review.repository.ReviewRepository;
@@ -14,10 +15,18 @@ import com.clubber.ClubberServer.domain.review.service.ReviewService;
 import com.clubber.ClubberServer.integration.util.ServiceTest;
 import com.clubber.ClubberServer.integration.util.WithMockCustomUser;
 import java.util.Optional;
+
+import com.clubber.ClubberServer.integration.util.fixture.ReviewFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@ActiveProfiles("test")
 public class ReviewServiceTest extends ServiceTest {
 
 	@Autowired
@@ -33,8 +42,8 @@ public class ReviewServiceTest extends ServiceTest {
 		/**
 		 * 1번 user club1에 리뷰 등록되어있음
 		 */
-		CreateClubReviewResponse reviewCreateResponse = reviewService.createReview(2L
-			, VALID_REVIEW_CREATE_REQUEST);
+		CreateClubReviewRequest createClubReviewRequest = ReviewFixture.getDefaultCreateClubReviewRequestBuilder().sample();
+		CreateClubReviewResponse reviewCreateResponse = reviewService.createReview(2L, createClubReviewRequest);
 
 		Optional<Review> createdReview = reviewRepository.findById(
 			reviewCreateResponse.getReviewId());

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
@@ -3,6 +3,8 @@ package com.clubber.ClubberServer.integration.util.fixture;
 import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminUsernameFindAuth;
+import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthVerifyRequest;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVerifyRequest;
 
 public class AdminEmailAuthFixture {
     public static Long CLUB_ID = 1L;
@@ -19,10 +21,18 @@ public class AdminEmailAuthFixture {
                 .authCode(AUTH_CODE);
     }
 
+    public static CreateAdminSignupAuthVerifyRequest 회원가입_이메일_인증_요청(String clubName, String email, Integer authCode) {
+        return new CreateAdminSignupAuthVerifyRequest(clubName, email, authCode);
+    }
+
     public static AdminPasswordFindAuth.AdminPasswordFindAuthBuilder aAdminPasswordFindAuth() {
         return AdminPasswordFindAuth.builder()
                 .username(USERNAME)
                 .authCode(AUTH_CODE);
+    }
+
+    public static UpdateAdminPasswordFindAuthVerifyRequest 비밀번호_찾기_인증_요청(String username, Integer authCode){
+        return new UpdateAdminPasswordFindAuthVerifyRequest(username, authCode);
     }
 
     public static AdminUsernameFindAuth.AdminUsernameFindAuthBuilder aAdminUsernameFindAuth() {

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
@@ -4,6 +4,7 @@ import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminUsernameFindAuth;
 import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthVerifyRequest;
+import com.clubber.ClubberServer.domain.admin.dto.GetAdminUsernameFindRequest;
 import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminPasswordFindAuthVerifyRequest;
 
 public class AdminEmailAuthFixture {
@@ -25,6 +26,7 @@ public class AdminEmailAuthFixture {
         return new CreateAdminSignupAuthVerifyRequest(clubName, email, authCode);
     }
 
+
     public static AdminPasswordFindAuth.AdminPasswordFindAuthBuilder aAdminPasswordFindAuth() {
         return AdminPasswordFindAuth.builder()
                 .username(USERNAME)
@@ -39,5 +41,9 @@ public class AdminEmailAuthFixture {
         return AdminUsernameFindAuth.builder()
                 .clubId(CLUB_ID)
                 .authCode(AUTH_CODE);
+    }
+
+    public static GetAdminUsernameFindRequest 아이디_찾기_인증_요청(Long clubId, String email, Integer authCode) {
+        return new GetAdminUsernameFindRequest(clubId, email, authCode);
     }
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminEmailAuthFixture.java
@@ -1,0 +1,33 @@
+package com.clubber.ClubberServer.integration.util.fixture;
+
+import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
+import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
+import com.clubber.ClubberServer.domain.admin.domain.AdminUsernameFindAuth;
+
+public class AdminEmailAuthFixture {
+    public static Long CLUB_ID = 1L;
+    public static String CLUB_NAME = "클러버";
+    public static String USERNAME = "clubber123";
+    public static String EMAIL = "ssuclubber@gmail.com";
+    public static Integer AUTH_CODE = 123456;
+
+
+    public static AdminSignupAuth.AdminSignupAuthBuilder aAdminSignupAuth() {
+        return AdminSignupAuth.builder()
+                .clubName(CLUB_NAME)
+                .email(EMAIL)
+                .authCode(AUTH_CODE);
+    }
+
+    public static AdminPasswordFindAuth.AdminPasswordFindAuthBuilder aAdminPasswordFindAuth() {
+        return AdminPasswordFindAuth.builder()
+                .username(USERNAME)
+                .authCode(AUTH_CODE);
+    }
+
+    public static AdminUsernameFindAuth.AdminUsernameFindAuthBuilder aAdminUsernameFindAuth() {
+        return AdminUsernameFindAuth.builder()
+                .clubId(CLUB_ID)
+                .authCode(AUTH_CODE);
+    }
+}

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -48,7 +48,7 @@ public class AdminFixture {
 				);
 	}
 
-	public static UpdateAdminsPasswordRequest getUpdateAdminsPasswordRequest(String oldPassword, String newPassword) {
+	public static UpdateAdminsPasswordRequest 마이페이지_비밀번호_변경_요청(String oldPassword, String newPassword) {
 		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
 				.set("oldPassword", oldPassword)
 				.set("newPassword", newPassword)

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -77,14 +77,15 @@ public class AdminFixture {
 				.build();
 	}
 
-	public static AdminPasswordFindAuth 비밀번호_찾기_인증(String email, Integer authCode){
+	public static AdminPasswordFindAuth 비밀번호_찾기_인증(String username, Integer authCode){
 		return AdminPasswordFindAuth.builder()
+				.username(username)
 				.authCode(authCode)
 				.build();
 	}
 
-	public static UpdateAdminPasswordFindAuthVerifyRequest 비밀번호찾기_인증번호_검증요청(String email, Integer authCode){
-		return new UpdateAdminPasswordFindAuthVerifyRequest(email, authCode);
+	public static UpdateAdminPasswordFindAuthVerifyRequest 비밀번호_찾기_인증_요청(String username, Integer authCode){
+		return new UpdateAdminPasswordFindAuthVerifyRequest(username, authCode);
 	}
 
 	public static Admin.AdminBuilder getDefaultAdminBuilder(){
@@ -111,5 +112,11 @@ public class AdminFixture {
 		return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
 				.set("username", "clubber")
 				.set("email", "ssuclubber@gmail.com");
+	}
+
+	public static ArbitraryBuilder<UpdateAdminPasswordFindAuthVerifyRequest> getDefaultUpdateAdminPasswordFindAuthVerifyRequest(){
+		return fixtureMonkey.giveMeBuilder(UpdateAdminPasswordFindAuthVerifyRequest.class)
+				.set("username", "clubber")
+				.set("authCode", 123456);
 	}
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -20,11 +20,7 @@ public class AdminFixture {
     public static final String OLD_PASSWORD = "oldPassword";
     public static final String NEW_PASSWORD = "newPassword";
     public static final String INSTAGRAM = "@clubber_ssu";
-
-
-    public static final UpdateAdminsPasswordRequest VALID_UPDATE_PASSWORD_REQUEST = new UpdateAdminsPasswordRequest("기존비밀번호",
-            "수정비밀번호");
-
+    
     public static final UpdateClubPageRequest VALID_UPDATE_CLUB_PAGE_REQUEST =
             new UpdateClubPageRequest("수정imagekey", "수정introduction", "수정instagram", "수정youtube", "수정activity",
                     "수정leader", 1000L);
@@ -54,9 +50,6 @@ public class AdminFixture {
                         new Contact(INSTAGRAM, null)
                 );
     }
-
-    public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
-            "동아리 1", "비밀번호 1");
 
     public static ArbitraryBuilder<CreateAdminsLoginRequest> a_관리자_로그인_요청() {
         return fixtureMonkey.giveMeBuilder(CreateAdminsLoginRequest.class)

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -5,11 +5,16 @@ import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
 import com.clubber.ClubberServer.domain.admin.domain.Contact;
 import com.clubber.ClubberServer.domain.admin.dto.*;
+import com.clubber.ClubberServer.domain.club.domain.Club;
+import com.clubber.ClubberServer.domain.club.domain.ClubInfo;
 import com.clubber.ClubberServer.domain.club.domain.ClubType;
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+import com.navercorp.fixturemonkey.FixtureMonkey;
 
 import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
+import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.*;
 
 public class AdminFixture {
 
@@ -95,7 +100,16 @@ public class AdminFixture {
 				);
 	}
 
-	public static UpdateAdminsPasswordRequest getUpdateAdminsPasswordRequest(String oldPassword, String newPassword){
-		return new UpdateAdminsPasswordRequest(oldPassword, newPassword);
+	public static UpdateAdminsPasswordRequest getUpdateAdminsPasswordRequest(String oldPassword, String newPassword) {
+		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
+				.set("oldPassword", oldPassword)
+				.set("newPassword", newPassword)
+				.sample();
+	}
+
+	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> getDefaultCreateAdminPasswordFindRequest(){
+		return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
+				.set("username", "clubber")
+				.set("email", "ssuclubber@gmail.com");
 	}
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -2,7 +2,10 @@ package com.clubber.ClubberServer.integration.util.fixture;
 
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
 import com.clubber.ClubberServer.domain.admin.domain.Contact;
-import com.clubber.ClubberServer.domain.admin.dto.*;
+import com.clubber.ClubberServer.domain.admin.dto.CreateAdminPasswordFindRequest;
+import com.clubber.ClubberServer.domain.admin.dto.CreateAdminsLoginRequest;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminsPasswordRequest;
+import com.clubber.ClubberServer.domain.admin.dto.UpdateClubPageRequest;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
 
 import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
@@ -12,62 +15,56 @@ import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.f
 
 public class AdminFixture {
 
-	public static final String USERNAME = "clubber123";
-	public static final String EMAIL = "ssuclubber@gmail.com";
-	public static final String OLD_PASSWORD = "oldPassword";
-	public static final String NEW_PASSWORD = "newPassword";
+    public static final String USERNAME = "clubber123";
+    public static final String EMAIL = "ssuclubber@gmail.com";
+    public static final String OLD_PASSWORD = "oldPassword";
+    public static final String NEW_PASSWORD = "newPassword";
 
-	public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
-		"동아리 1", "비밀번호 1");
+    public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
+            "동아리 1", "비밀번호 1");
 
-	public static final UpdateAdminsPasswordRequest VALID_UPDATE_PASSWORD_REQUEST = new UpdateAdminsPasswordRequest("기존비밀번호",
-		"수정비밀번호");
+    public static final UpdateAdminsPasswordRequest VALID_UPDATE_PASSWORD_REQUEST = new UpdateAdminsPasswordRequest("기존비밀번호",
+            "수정비밀번호");
 
-	public static final UpdateClubPageRequest VALID_UPDATE_CLUB_PAGE_REQUEST =
-		new UpdateClubPageRequest("수정imagekey", "수정introduction", "수정instagram", "수정youtube","수정activity",
-			"수정leader", 1000L);
+    public static final UpdateClubPageRequest VALID_UPDATE_CLUB_PAGE_REQUEST =
+            new UpdateClubPageRequest("수정imagekey", "수정introduction", "수정instagram", "수정youtube", "수정activity",
+                    "수정leader", 1000L);
 
-	public static final UpdateClubPageRequest IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST =
-		new UpdateClubPageRequest(IMAGE_SERVER + "수정imagekey", "수정introduction", "수정instagram","수정youtube",
-			"수정activity", "수정leader", 1000L);
+    public static final UpdateClubPageRequest IMAGE_KEY_WITH_IMAGE_SERVER_PAGE_REQUEST =
+            new UpdateClubPageRequest(IMAGE_SERVER + "수정imagekey", "수정introduction", "수정instagram", "수정youtube",
+                    "수정activity", "수정leader", 1000L);
 
-	public static final UpdateClubPageRequest OVER_MAX_LENGTH_ACTIVITY_UPDATE_PAGE_REQUEST =
-		new UpdateClubPageRequest("imagekey", "introduction", "instagram","youtube", "a".repeat(1501),
-			"leader", 1000L);
+    public static final UpdateClubPageRequest OVER_MAX_LENGTH_ACTIVITY_UPDATE_PAGE_REQUEST =
+            new UpdateClubPageRequest("imagekey", "introduction", "instagram", "youtube", "a".repeat(1501),
+                    "leader", 1000L);
 
-	public static final UpdateClubPageRequest OVER_MAX_LENGTH_INTRODUCTION_UPDATE_PAGE_REQUEST =
-		new UpdateClubPageRequest("imagekey", "a".repeat(101), "instagram", "youtube", "activity", "leader",
-			1000L);
+    public static final UpdateClubPageRequest OVER_MAX_LENGTH_INTRODUCTION_UPDATE_PAGE_REQUEST =
+            new UpdateClubPageRequest("imagekey", "a".repeat(101), "instagram", "youtube", "activity", "leader",
+                    1000L);
 
 
-	public static Admin.AdminBuilder aAdmin(){
-		return Admin.builder()
-				.id(1L)
-				.username("clubber")
-				.email("ssuclubber@gmail.com")
-				.password("password")
-				.accountState(ACTIVE)
-				.accountRole(ADMIN)
-				.contact(
-						new Contact("@clubber_ssu", null)
-				);
-	}
+    public static Admin.AdminBuilder aAdmin() {
+        return Admin.builder()
+                .id(1L)
+                .username("clubber")
+                .email("ssuclubber@gmail.com")
+                .password("password")
+                .accountState(ACTIVE)
+                .accountRole(ADMIN)
+                .contact(
+                        new Contact("@clubber_ssu", null)
+                );
+    }
 
-	public static ArbitraryBuilder<UpdateAdminsPasswordRequest> a_마이페이지_비밀번호_변경_요청() {
-		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
-				.set("oldPassword", OLD_PASSWORD)
-				.set("newPassword", NEW_PASSWORD);
-	}
+    public static ArbitraryBuilder<UpdateAdminsPasswordRequest> a_마이페이지_비밀번호_변경_요청() {
+        return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
+                .set("oldPassword", OLD_PASSWORD)
+                .set("newPassword", NEW_PASSWORD);
+    }
 
-	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> a_비밀번호_찾기_요청(){
-		return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
-				.set("username", USERNAME)
-				.set("email", EMAIL);
-	}
-
-	public static ArbitraryBuilder<UpdateAdminPasswordFindAuthVerifyRequest> getDefaultUpdateAdminPasswordFindAuthVerifyRequest(){
-		return fixtureMonkey.giveMeBuilder(UpdateAdminPasswordFindAuthVerifyRequest.class)
-				.set("username", "clubber")
-				.set("authCode", 123456);
-	}
+    public static ArbitraryBuilder<CreateAdminPasswordFindRequest> a_비밀번호_찾기_요청() {
+        return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
+                .set("username", USERNAME)
+                .set("email", EMAIL);
+    }
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -12,6 +12,8 @@ import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.f
 
 public class AdminFixture {
 
+	public static final String USERNAME = "clubber123";
+	public static final String EMAIL = "ssuclubber@gmail.com";
 	public static final String OLD_PASSWORD = "oldPassword";
 	public static final String NEW_PASSWORD = "newPassword";
 
@@ -57,10 +59,10 @@ public class AdminFixture {
 				.set("newPassword", NEW_PASSWORD);
 	}
 
-	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> getDefaultCreateAdminPasswordFindRequest(){
+	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> a_비밀번호_찾기_요청(){
 		return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
-				.set("username", "clubber")
-				.set("email", "ssuclubber@gmail.com");
+				.set("username", USERNAME)
+				.set("email", EMAIL);
 	}
 
 	public static ArbitraryBuilder<UpdateAdminPasswordFindAuthVerifyRequest> getDefaultUpdateAdminPasswordFindAuthVerifyRequest(){

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -55,6 +55,12 @@ public class AdminFixture {
 				.sample();
 	}
 
+	public static ArbitraryBuilder<UpdateAdminsPasswordRequest> a_마이페이지_비밀번호_변경_요청() {
+		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
+				.set("oldPassword", "oldPassword")
+				.set("newPassword", "oldPassword");
+	}
+
 	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> getDefaultCreateAdminPasswordFindRequest(){
 		return fixtureMonkey.giveMeBuilder(CreateAdminPasswordFindRequest.class)
 				.set("username", "clubber")

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -5,11 +5,7 @@ import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
 import com.clubber.ClubberServer.domain.admin.domain.Contact;
 import com.clubber.ClubberServer.domain.admin.dto.*;
-import com.clubber.ClubberServer.domain.club.domain.Club;
-import com.clubber.ClubberServer.domain.club.domain.ClubInfo;
-import com.clubber.ClubberServer.domain.club.domain.ClubType;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
-import com.navercorp.fixturemonkey.FixtureMonkey;
 
 import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
@@ -67,7 +63,7 @@ public class AdminFixture {
 		return new UpdateAdminPasswordFindAuthVerifyRequest(username, authCode);
 	}
 
-	public static Admin.AdminBuilder getDefaultAdminBuilder(){
+	public static Admin.AdminBuilder aAdmin(){
 		return Admin.builder()
 				.id(1L)
 				.username("clubber")

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -19,6 +19,7 @@ public class AdminFixture {
     public static final String EMAIL = "ssuclubber@gmail.com";
     public static final String OLD_PASSWORD = "oldPassword";
     public static final String NEW_PASSWORD = "newPassword";
+    public static final String INSTAGRAM = "@clubber_ssu";
 
     public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
             "동아리 1", "비밀번호 1");
@@ -46,13 +47,13 @@ public class AdminFixture {
     public static Admin.AdminBuilder aAdmin() {
         return Admin.builder()
                 .id(1L)
-                .username("clubber")
-                .email("ssuclubber@gmail.com")
-                .password("password")
+                .username(USERNAME)
+                .email(EMAIL)
+                .password(OLD_PASSWORD)
                 .accountState(ACTIVE)
                 .accountRole(ADMIN)
                 .contact(
-                        new Contact("@clubber_ssu", null)
+                        new Contact(INSTAGRAM, null)
                 );
     }
 

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -12,6 +12,9 @@ import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.f
 
 public class AdminFixture {
 
+	public static final String OLD_PASSWORD = "oldPassword";
+	public static final String NEW_PASSWORD = "newPassword";
+
 	public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
 		"동아리 1", "비밀번호 1");
 
@@ -48,17 +51,10 @@ public class AdminFixture {
 				);
 	}
 
-	public static UpdateAdminsPasswordRequest 마이페이지_비밀번호_변경_요청(String oldPassword, String newPassword) {
-		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
-				.set("oldPassword", oldPassword)
-				.set("newPassword", newPassword)
-				.sample();
-	}
-
 	public static ArbitraryBuilder<UpdateAdminsPasswordRequest> a_마이페이지_비밀번호_변경_요청() {
 		return fixtureMonkey.giveMeBuilder(UpdateAdminsPasswordRequest.class)
-				.set("oldPassword", "oldPassword")
-				.set("newPassword", "oldPassword");
+				.set("oldPassword", OLD_PASSWORD)
+				.set("newPassword", NEW_PASSWORD);
 	}
 
 	public static ArbitraryBuilder<CreateAdminPasswordFindRequest> getDefaultCreateAdminPasswordFindRequest(){

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -1,8 +1,6 @@
 package com.clubber.ClubberServer.integration.util.fixture;
 
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
-import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
-import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
 import com.clubber.ClubberServer.domain.admin.domain.Contact;
 import com.clubber.ClubberServer.domain.admin.dto.*;
 import com.navercorp.fixturemonkey.ArbitraryBuilder;
@@ -10,7 +8,7 @@ import com.navercorp.fixturemonkey.ArbitraryBuilder;
 import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
-import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.*;
+import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.fixtureMonkey;
 
 public class AdminFixture {
 
@@ -36,32 +34,6 @@ public class AdminFixture {
 		new UpdateClubPageRequest("imagekey", "a".repeat(101), "instagram", "youtube", "activity", "leader",
 			1000L);
 
-	public static CreateAdminPasswordFindRequest 인증_메일_전송_요청(String username, String email){
-		return new CreateAdminPasswordFindRequest(username, email);
-	}
-
-	public static CreateAdminSignupAuthVerifyRequest 회원가입_이메일_인증_요청(String clubName, String email, Integer authCode) {
-		return new CreateAdminSignupAuthVerifyRequest(clubName, email, authCode);
-	}
-
-	public static AdminSignupAuth 회원가입_이메일_인증(String clubName, String email, Integer authCode) {
-		return AdminSignupAuth.builder()
-				.clubName(clubName)
-				.email(email)
-				.authCode(authCode)
-				.build();
-	}
-
-	public static AdminPasswordFindAuth 비밀번호_찾기_인증(String username, Integer authCode){
-		return AdminPasswordFindAuth.builder()
-				.username(username)
-				.authCode(authCode)
-				.build();
-	}
-
-	public static UpdateAdminPasswordFindAuthVerifyRequest 비밀번호_찾기_인증_요청(String username, Integer authCode){
-		return new UpdateAdminPasswordFindAuthVerifyRequest(username, authCode);
-	}
 
 	public static Admin.AdminBuilder aAdmin(){
 		return Admin.builder()

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -1,10 +1,14 @@
 package com.clubber.ClubberServer.integration.util.fixture;
 
+import com.clubber.ClubberServer.domain.admin.domain.Admin;
 import com.clubber.ClubberServer.domain.admin.domain.AdminPasswordFindAuth;
 import com.clubber.ClubberServer.domain.admin.domain.AdminSignupAuth;
+import com.clubber.ClubberServer.domain.admin.domain.Contact;
 import com.clubber.ClubberServer.domain.admin.dto.*;
 import com.clubber.ClubberServer.domain.club.domain.ClubType;
 
+import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
+import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
 
 public class AdminFixture {
@@ -38,7 +42,7 @@ public class AdminFixture {
 		ClubType clubType,
 		String clubName,
 		String email,
-		String contact,
+		Contact contact,
 		String imageForApproval) {
 
 		return new CreateAdminSignUpRequest(
@@ -52,16 +56,17 @@ public class AdminFixture {
 		);
 	}
 
-	public static CreateAdminSignupAuthRequest 인증_메일_전송_요청(String email){
-		return new CreateAdminSignupAuthRequest(email);
+	public static CreateAdminPasswordFindRequest 인증_메일_전송_요청(String username, String email){
+		return new CreateAdminPasswordFindRequest(username, email);
 	}
 
-	public static CreateAdminSignupAuthVerifyRequest 회원가입_이메일_인증_요청(String email, Integer authCode) {
-		return new CreateAdminSignupAuthVerifyRequest(email, authCode);
+	public static CreateAdminSignupAuthVerifyRequest 회원가입_이메일_인증_요청(String clubName, String email, Integer authCode) {
+		return new CreateAdminSignupAuthVerifyRequest(clubName, email, authCode);
 	}
 
-	public static AdminSignupAuth 회원가입_이메일_인증(String email, Integer authCode) {
+	public static AdminSignupAuth 회원가입_이메일_인증(String clubName, String email, Integer authCode) {
 		return AdminSignupAuth.builder()
+				.clubName(clubName)
 				.email(email)
 				.authCode(authCode)
 				.build();
@@ -69,7 +74,6 @@ public class AdminFixture {
 
 	public static AdminPasswordFindAuth 비밀번호_찾기_인증(String email, Integer authCode){
 		return AdminPasswordFindAuth.builder()
-				.email(email)
 				.authCode(authCode)
 				.build();
 	}
@@ -78,7 +82,20 @@ public class AdminFixture {
 		return new UpdateAdminPasswordFindAuthVerifyRequest(email, authCode);
 	}
 
-	public static UpdateAdminsPasswordRequest 관리자_비밀번호_변경_요청(String oldPassword, String newPassword){
+	public static Admin.AdminBuilder getDefaultAdminBuilder(){
+		return Admin.builder()
+				.id(1L)
+				.username("clubber")
+				.email("ssuclubber@gmail.com")
+				.password("password")
+				.accountState(ACTIVE)
+				.accountRole(ADMIN)
+				.contact(
+						new Contact("@clubber_ssu", null)
+				);
+	}
+
+	public static UpdateAdminsPasswordRequest getUpdateAdminsPasswordRequest(String oldPassword, String newPassword){
 		return new UpdateAdminsPasswordRequest(oldPassword, newPassword);
 	}
 }

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/AdminFixture.java
@@ -21,8 +21,6 @@ public class AdminFixture {
     public static final String NEW_PASSWORD = "newPassword";
     public static final String INSTAGRAM = "@clubber_ssu";
 
-    public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
-            "동아리 1", "비밀번호 1");
 
     public static final UpdateAdminsPasswordRequest VALID_UPDATE_PASSWORD_REQUEST = new UpdateAdminsPasswordRequest("기존비밀번호",
             "수정비밀번호");
@@ -55,6 +53,15 @@ public class AdminFixture {
                 .contact(
                         new Contact(INSTAGRAM, null)
                 );
+    }
+
+    public static final CreateAdminsLoginRequest VALID_ADMIN_REQUEST = new CreateAdminsLoginRequest(
+            "동아리 1", "비밀번호 1");
+
+    public static ArbitraryBuilder<CreateAdminsLoginRequest> a_관리자_로그인_요청() {
+        return fixtureMonkey.giveMeBuilder(CreateAdminsLoginRequest.class)
+                .set("username", USERNAME)
+                .set("password", OLD_PASSWORD);
     }
 
     public static ArbitraryBuilder<UpdateAdminsPasswordRequest> a_마이페이지_비밀번호_변경_요청() {

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/ClubFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/ClubFixture.java
@@ -1,0 +1,58 @@
+package com.clubber.ClubberServer.integration.util.fixture;
+
+import com.clubber.ClubberServer.domain.admin.dto.UpdateClubPageRequest;
+import com.clubber.ClubberServer.domain.club.domain.Club;
+import com.clubber.ClubberServer.domain.club.domain.ClubInfo;
+import com.clubber.ClubberServer.domain.club.domain.ClubType;
+import com.clubber.ClubberServer.domain.club.domain.Department;
+import com.clubber.ClubberServer.global.vo.image.ImageVO;
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+
+import static com.clubber.ClubberServer.domain.club.domain.College.ETC;
+import static com.clubber.ClubberServer.domain.club.domain.Division.ACADEMIC;
+import static com.clubber.ClubberServer.domain.club.domain.Hashtag.PROGRAMMING;
+import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.fixtureMonkey;
+
+public class ClubFixture {
+    public static final String CLUB_NAME = "클러버";
+    public static final String CLUB_INTRODUCTION = "클러버를 소개합니다.";
+    public static final String IMAGE_KEY = "/prod/clubber/imageKey";
+
+    public static final String INSTAGRAM = "@clubber_ssu";
+    public static final String YOUTUBE = "clubber_channel";
+    public static final String LEADER = "클러버_회장님";
+    public static final Long ROOM = 100L;
+    public static final String ACTIVITY = "클러버_활동_소개";
+
+    public static Club.ClubBuilder aClub() {
+        return Club.builder()
+                .name(CLUB_NAME)
+                .clubType(ClubType.CENTER)
+                .introduction(CLUB_INTRODUCTION)
+                .hashtag(PROGRAMMING)
+                .division(ACADEMIC)
+                .college(ETC)
+                .department(Department.ETC)
+                .imageUrl(ImageVO.valueOf(IMAGE_KEY));
+    }
+
+    public static ClubInfo.ClubInfoBuilder aClubInfo() {
+        return ClubInfo.builder()
+                .instagram(INSTAGRAM)
+                .youtube(YOUTUBE)
+                .leader(LEADER)
+                .room(ROOM)
+                .activity(ACTIVITY);
+    }
+
+    public static ArbitraryBuilder<UpdateClubPageRequest> a_관리자_동아리_페이지_수정_요청() {
+        return fixtureMonkey.giveMeBuilder(UpdateClubPageRequest.class)
+                .set("imageKey", IMAGE_KEY)
+                .set("introduction", CLUB_INTRODUCTION)
+                .set("instagram", INSTAGRAM)
+                .set("youtube", YOUTUBE)
+                .set("activity", ACTIVITY)
+                .set("leader", LEADER)
+                .set("room", ROOM);
+    }
+}

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/FixtureCommon.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/FixtureCommon.java
@@ -1,0 +1,20 @@
+package com.clubber.ClubberServer.integration.util.fixture;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.BeanArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FailoverIntrospector;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+
+import java.util.Arrays;
+
+public class FixtureCommon {
+    public static FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(new FailoverIntrospector(
+                    Arrays.asList(
+                            FieldReflectionArbitraryIntrospector.INSTANCE,
+                            BeanArbitraryIntrospector.INSTANCE,
+                            BuilderArbitraryIntrospector.INSTANCE
+                    )
+            )).build();
+}

--- a/src/test/java/com/clubber/ClubberServer/integration/util/fixture/ReviewFixture.java
+++ b/src/test/java/com/clubber/ClubberServer/integration/util/fixture/ReviewFixture.java
@@ -1,8 +1,13 @@
 package com.clubber.ClubberServer.integration.util.fixture;
 
+import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminsPasswordRequest;
 import com.clubber.ClubberServer.domain.review.domain.Keyword;
 import com.clubber.ClubberServer.domain.review.dto.CreateClubReviewRequest;
+import com.navercorp.fixturemonkey.ArbitraryBuilder;
+
 import java.util.List;
+
+import static com.clubber.ClubberServer.integration.util.fixture.FixtureCommon.fixtureMonkey;
 
 public class ReviewFixture {
 
@@ -14,4 +19,11 @@ public class ReviewFixture {
 
 	public static final CreateClubReviewRequest LONG_SIZE_INVALID_REVIEW_REQUEST =
 		new CreateClubReviewRequest("a".repeat(101), List.of(Keyword.CULTURE), "image");
+
+	public static ArbitraryBuilder<CreateClubReviewRequest> getDefaultCreateClubReviewRequestBuilder() {
+		return fixtureMonkey.giveMeBuilder(CreateClubReviewRequest.class)
+				.set("content", "content")
+				.set("keywords", List.of(Keyword.CULTURE, Keyword.FEE))
+				.set("authImage", "authImage");
+	}
 }

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
@@ -1,10 +1,8 @@
 package com.clubber.ClubberServer.unit.domain.admin.facade;
 
 import com.clubber.ClubberServer.domain.admin.dto.CreateAdminPasswordFindRequest;
-import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthRequest;
 import com.clubber.ClubberServer.domain.admin.facade.AdminEmailAuthFacade;
 import com.clubber.ClubberServer.domain.admin.repository.AdminRepository;
-import com.clubber.ClubberServer.domain.admin.service.AdminEmailAuthService;
 import com.clubber.ClubberServer.global.infrastructure.outer.mail.MailService;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -24,9 +22,6 @@ public class AdminEmailAuthFacadeTest {
     private AdminEmailAuthFacade adminEmailAuthFacade;
 
     @Mock
-    private AdminEmailAuthService adminEmailAuthService;
-
-    @Mock
     private AdminRepository adminRepository;
 
     @Mock
@@ -36,12 +31,10 @@ public class AdminEmailAuthFacadeTest {
     @DisplayName("존재하지 않는 이메일로 비밀번호 찾기를 요청할 경우 메일이 전송되지 않는다.")
     void createAdminPasswordFindNotFoundEmail(){
         //given
-        String email = "test@gmail.com";
-        String username = "test";
-        CreateAdminPasswordFindRequest request = AdminFixture.인증_메일_전송_요청(username, email);
+        CreateAdminPasswordFindRequest request = AdminFixture.getDefaultCreateAdminPasswordFindRequest().sample();
 
         //when
-        when(adminRepository.existsByEmailAndUsernameAndAccountState(username, email, ACTIVE)).thenReturn(false);
+        when(adminRepository.existsByEmailAndUsernameAndAccountState(anyString(), anyString(), eq(ACTIVE))).thenReturn(false);
         adminEmailAuthFacade.createAdminPasswordFind(request);
 
         //then

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
@@ -28,12 +28,13 @@ public class AdminEmailAuthFacadeTest {
     private MailService mailService;
 
     @Test
-    @DisplayName("존재하지 않는 이메일로 비밀번호 찾기를 요청할 경우 메일이 전송되지 않는다.")
-    void createAdminPasswordFindNotFoundEmail(){
+    @DisplayName("잘못된 이메일로 비밀번호 찾기를 요청할 경우 메일이 전송되지 않는다.")
+    void createAdminPasswordFindNotFoundEmail() {
         //given
-        CreateAdminPasswordFindRequest request = AdminFixture.getDefaultCreateAdminPasswordFindRequest().sample();
+        CreateAdminPasswordFindRequest request = AdminFixture.a_비밀번호_찾기_요청().sample();
 
         //when
+        when(adminRepository.existsByUsernameAndAccountState(anyString(), eq(ACTIVE))).thenReturn(true);
         when(adminRepository.existsByEmailAndUsernameAndAccountState(anyString(), anyString(), eq(ACTIVE))).thenReturn(false);
         adminEmailAuthFacade.createAdminPasswordFind(request);
 

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/facade/AdminEmailAuthFacadeTest.java
@@ -1,5 +1,6 @@
 package com.clubber.ClubberServer.unit.domain.admin.facade;
 
+import com.clubber.ClubberServer.domain.admin.dto.CreateAdminPasswordFindRequest;
 import com.clubber.ClubberServer.domain.admin.dto.CreateAdminSignupAuthRequest;
 import com.clubber.ClubberServer.domain.admin.facade.AdminEmailAuthFacade;
 import com.clubber.ClubberServer.domain.admin.repository.AdminRepository;
@@ -36,10 +37,11 @@ public class AdminEmailAuthFacadeTest {
     void createAdminPasswordFindNotFoundEmail(){
         //given
         String email = "test@gmail.com";
-        CreateAdminSignupAuthRequest request = AdminFixture.인증_메일_전송_요청(email);
+        String username = "test";
+        CreateAdminPasswordFindRequest request = AdminFixture.인증_메일_전송_요청(username, email);
 
         //when
-        when(adminRepository.existsByEmailAndAccountState(email, ACTIVE)).thenReturn(false);
+        when(adminRepository.existsByEmailAndUsernameAndAccountState(username, email, ACTIVE)).thenReturn(false);
         adminEmailAuthFacade.createAdminPasswordFind(request);
 
         //then

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -8,7 +8,6 @@ import com.clubber.ClubberServer.domain.admin.service.AdminReadService;
 import com.clubber.ClubberServer.domain.admin.validator.AdminValidator;
 import com.clubber.ClubberServer.global.event.withdraw.SoftDeleteEventPublisher;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -84,8 +83,7 @@ public class AdminAccountServiceTest {
     }
 
     @Test
-    @DisplayName("관리자 회원 탈퇴시 계정 상태가 변경된다.")
-    public void adminWithDrawTest() {
+    public void 관리자_회원탈퇴_계정_상태_변경() {
         //given
         Admin admin = AdminFixture.aAdmin().build();
         when(adminReadService.getCurrentAdmin()).thenReturn(admin);

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -54,7 +54,7 @@ public class AdminAccountServiceTest {
 
 		//then
 		assertThat(response).isNotNull();
-		assertThat(response.getClubName()).isEqualTo("club1");
+//		assertThat(response.getClubName()).isEqualTo("club1");
 	}
 
 	@Test

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -6,7 +6,6 @@ import com.clubber.ClubberServer.domain.admin.dto.UpdateAdminsPasswordRequest;
 import com.clubber.ClubberServer.domain.admin.service.AdminAccountService;
 import com.clubber.ClubberServer.domain.admin.service.AdminReadService;
 import com.clubber.ClubberServer.domain.admin.validator.AdminValidator;
-import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.global.event.withdraw.SoftDeleteEventPublisher;
 import com.clubber.ClubberServer.integration.util.fixture.AdminFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -17,8 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
-import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.INACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -100,24 +97,5 @@ public class AdminAccountServiceTest {
 
         //then
         assertThat(admin.getAccountState()).isEqualTo(INACTIVE);
-    }
-
-    private Admin getAdmin() {
-        return Admin.builder()
-                .id(1L)
-                .accountRole(ADMIN)
-                .accountState(ACTIVE)
-                .password("password")
-                .username("username")
-                .club(getClub())
-                .build();
-    }
-
-    private static Club getClub() {
-        return Club.builder()
-                .id(1L)
-                .name("club1")
-                .isAgreeToReview(true)
-                .build();
     }
 }

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -21,92 +21,95 @@ import static com.clubber.ClubberServer.domain.user.domain.AccountRole.ADMIN;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.ACTIVE;
 import static com.clubber.ClubberServer.domain.user.domain.AccountState.INACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AdminAccountServiceTest {
 
-	@InjectMocks
-	private AdminAccountService adminAccountService;
+    @InjectMocks
+    private AdminAccountService adminAccountService;
 
-	@Mock
-	private AdminReadService adminReadService;
+    @Mock
+    private AdminReadService adminReadService;
 
-	@Mock
-	private AdminValidator adminValidator;
+    @Mock
+    private AdminValidator adminValidator;
 
-	@Mock
-	private PasswordEncoder passwordEncoder;
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
-	@Mock
-	private SoftDeleteEventPublisher softDeleteEventPublisher;
+    @Mock
+    private SoftDeleteEventPublisher softDeleteEventPublisher;
 
-	@Test
-	@DisplayName("관리자 프로필 조회를 수행한다.")
-	public void getAdminsAccountProfile() {
-		//given
-		Admin admin = getAdmin();
-		when(adminReadService.getCurrentAdmin()).thenReturn(admin);
+    @Test
+    public void 관리자_프로필_조회() {
+        //given
+        Admin admin = AdminFixture.aAdmin().build();
+        when(adminReadService.getCurrentAdmin()).thenReturn(admin);
 
-		//when
-		GetAdminsProfileResponse response = adminAccountService.getAdminsProfile();
+        //when
+        GetAdminsProfileResponse response = adminAccountService.getAdminsProfile();
 
-		//then
-		assertThat(response).isNotNull();
-//		assertThat(response.getClubName()).isEqualTo("club1");
-	}
+        //then
+        assertAll(
+                () -> assertThat(response.username()).isEqualTo(admin.getUsername()),
+                () -> assertThat(response.contact()).isEqualTo(admin.getContact()),
+                () -> assertThat(response.email()).isEqualTo(admin.getEmail())
+        );
+    }
 
-	@Test
-	@DisplayName("관리자 비밀번호 정보를 수행한다.")
-	public void updateAdminsPasswordTest() {
-		//given
-		Admin admin = getAdmin();
-		UpdateAdminsPasswordRequest updatePasswordRequest = AdminFixture.VALID_UPDATE_PASSWORD_REQUEST;
-		when(adminReadService.getCurrentAdmin()).thenReturn(admin);
-		doNothing().when(adminValidator).validateEqualsWithExistPassword(anyString(), anyString());
-		when(passwordEncoder.encode(updatePasswordRequest.getNewPassword())).thenReturn(
-			"newPassword");
+    @Test
+    @DisplayName("관리자 비밀번호 정보를 수행한다.")
+    public void updateAdminsPasswordTest() {
+        //given
+        Admin admin = getAdmin();
+        UpdateAdminsPasswordRequest updatePasswordRequest = AdminFixture.VALID_UPDATE_PASSWORD_REQUEST;
+        when(adminReadService.getCurrentAdmin()).thenReturn(admin);
+        doNothing().when(adminValidator).validateEqualsWithExistPassword(anyString(), anyString());
+        when(passwordEncoder.encode(updatePasswordRequest.getNewPassword())).thenReturn(
+                "newPassword");
 
-		//when
-		adminAccountService.updateAdminsPassword(updatePasswordRequest);
+        //when
+        adminAccountService.updateAdminsPassword(updatePasswordRequest);
 
-		//then
-		assertThat(admin.getPassword()).isNotNull();
-		assertThat(admin.getPassword()).isEqualTo("newPassword");
-	}
+        //then
+        assertThat(admin.getPassword()).isNotNull();
+        assertThat(admin.getPassword()).isEqualTo("newPassword");
+    }
 
-	@Test
-	@DisplayName("관리자 회원 탈퇴시 계정 상태가 변경된다.")
-	public void adminWithDrawTest() {
-		//given
-		Admin admin = getAdmin();
-		when(adminReadService.getCurrentAdmin()).thenReturn(admin);
-		doNothing().when(softDeleteEventPublisher).throwSoftDeleteEvent(anyLong());
+    @Test
+    @DisplayName("관리자 회원 탈퇴시 계정 상태가 변경된다.")
+    public void adminWithDrawTest() {
+        //given
+        Admin admin = getAdmin();
+        when(adminReadService.getCurrentAdmin()).thenReturn(admin);
+        doNothing().when(softDeleteEventPublisher).throwSoftDeleteEvent(anyLong());
 
-		//when
-		adminAccountService.withDraw();
+        //when
+        adminAccountService.withDraw();
 
-		//then
-		assertThat(admin.getAccountState()).isEqualTo(INACTIVE);
-	}
+        //then
+        assertThat(admin.getAccountState()).isEqualTo(INACTIVE);
+    }
 
-	private Admin getAdmin() {
-		return Admin.builder()
-			.id(1L)
-			.accountRole(ADMIN)
-			.accountState(ACTIVE)
-			.password("password")
-			.username("username")
-			.club(getClub())
-			.build();
-	}
+    private Admin getAdmin() {
+        return Admin.builder()
+                .id(1L)
+                .accountRole(ADMIN)
+                .accountState(ACTIVE)
+                .password("password")
+                .username("username")
+                .club(getClub())
+                .build();
+    }
 
-	private static Club getClub() {
-		return Club.builder()
-			.id(1L)
-			.name("club1")
-			.isAgreeToReview(true)
-			.build();
-	}
+    private static Club getClub() {
+        return Club.builder()
+                .id(1L)
+                .name("club1")
+                .isAgreeToReview(true)
+                .build();
+    }
 }

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -90,8 +90,9 @@ public class AdminAccountServiceTest {
     @DisplayName("관리자 회원 탈퇴시 계정 상태가 변경된다.")
     public void adminWithDrawTest() {
         //given
-        Admin admin = getAdmin();
+        Admin admin = AdminFixture.aAdmin().build();
         when(adminReadService.getCurrentAdmin()).thenReturn(admin);
+
         doNothing().when(softDeleteEventPublisher).throwSoftDeleteEvent(anyLong());
 
         //when

--- a/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/clubber/ClubberServer/unit/domain/admin/service/AdminAccountServiceTest.java
@@ -61,22 +61,29 @@ public class AdminAccountServiceTest {
     }
 
     @Test
-    @DisplayName("관리자 비밀번호 정보를 수행한다.")
-    public void updateAdminsPasswordTest() {
+    public void 관리자_비밀번호_변경() {
         //given
-        Admin admin = getAdmin();
-        UpdateAdminsPasswordRequest updatePasswordRequest = AdminFixture.VALID_UPDATE_PASSWORD_REQUEST;
+        final String oldPassword = "oldPassword";
+        final String newPassword = "newPassword";
+        Admin admin = AdminFixture.aAdmin()
+                .password(oldPassword)
+                .build();
         when(adminReadService.getCurrentAdmin()).thenReturn(admin);
+
         doNothing().when(adminValidator).validateEqualsWithExistPassword(anyString(), anyString());
-        when(passwordEncoder.encode(updatePasswordRequest.getNewPassword())).thenReturn(
-                "newPassword");
+        doNothing().when(adminValidator).validatePasswordInUpdatePassword(anyString(), anyString());
+
+        UpdateAdminsPasswordRequest request = AdminFixture.a_마이페이지_비밀번호_변경_요청()
+                .set("newPassword", newPassword)
+                .sample();
+        when(passwordEncoder.encode(anyString())).thenReturn(newPassword);
 
         //when
-        adminAccountService.updateAdminsPassword(updatePasswordRequest);
+        adminAccountService.updateAdminsPassword(request);
 
         //then
         assertThat(admin.getPassword()).isNotNull();
-        assertThat(admin.getPassword()).isEqualTo("newPassword");
+        assertThat(admin.getPassword()).isEqualTo(newPassword);
     }
 
     @Test


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->

## Key Changes
- [x] ServiceTest (SQL기반 setup 코드) 상속 제거하여 각 테스트 함수 별 set up 독립적으로 수행 
- [x] JPA Entity Set up : 각 Fixture 클래스에서 @Builder를 이용하여 기본 Builder 반환 후 테스트 함수에서 필요한 Fixture 덮어씌우는 방식으로 수행 
- [x] Request DTO : @Builder가 기존에 없기 때문에, fixture Monkey 기반 DTO Builder 반환 
- [x] Admin 관련 테스트 코드 Set up 수정 반영

## ETC 
