### PR TITLE
refactor : 비동기 작업 MDC(쓰레드 정보)값 Clone 설정 추가 (#792)

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/global/config/async/AsyncConfig.java
+++ b/src/main/java/com/clubber/ClubberServer/global/config/async/AsyncConfig.java
@@ -28,6 +28,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
         executor.initialize();
+        executor.setTaskDecorator(new ClonedTaskDecorator());
         return executor;
     }
 

--- a/src/main/java/com/clubber/ClubberServer/global/config/async/ClonedTaskDecorator.java
+++ b/src/main/java/com/clubber/ClubberServer/global/config/async/ClonedTaskDecorator.java
@@ -1,0 +1,17 @@
+package com.clubber.ClubberServer.global.config.async;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+public class ClonedTaskDecorator implements TaskDecorator {
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Map<String, String> callerThreadContext = MDC.getCopyOfContextMap();
+        return () -> {
+            MDC.setContextMap(callerThreadContext);
+            runnable.run();
+        };
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
비동기 작업시 새로운 쓰레드 생성되므로 쓰레드 정보 포함(로깅) 안됨 
기존 쓰레드 id를 포함하는 MDC 클래스를 비동기 쓰레드에 copy하게 처리

## Key Changes
- [ ] AsyncConfigurer, TaskDecorator

## ETC 
