### PR TITLE
refactor : 연동 캘린더 관련 코드 패키지 

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarController.java
@@ -1,6 +1,9 @@
 package com.clubber.ClubberServer.domain.calendar.controller;
 
-import com.clubber.ClubberServer.domain.calendar.dto.*;
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarResponse;
+import com.clubber.ClubberServer.domain.calendar.dto.GetCalendarResponse;
+import com.clubber.ClubberServer.domain.calendar.dto.UpdateCalendarRequest;
 import com.clubber.ClubberServer.domain.calendar.service.CalendarService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -14,11 +17,6 @@ public class CalendarController {
     @PostMapping
     public CreateCalendarResponse createCalendar(@RequestBody CreateCalendarRequest request) {
         return calendarService.createCalendar(request);
-    }
-
-    @PostMapping("/linked")
-    public CreateLinkedCalenderResponse createLinkedCalender(@RequestBody CreateLinkedCalendarRequest request) {
-        return calendarService.createLinkedCalender(request);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarService.java
@@ -1,11 +1,12 @@
 package com.clubber.ClubberServer.domain.calendar.service;
 
-import com.clubber.ClubberServer.domain.calendar.dto.*;
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarResponse;
+import com.clubber.ClubberServer.domain.calendar.dto.GetCalendarResponse;
+import com.clubber.ClubberServer.domain.calendar.dto.UpdateCalendarRequest;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
-import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
-import com.clubber.ClubberServer.domain.recruit.implement.RecruitReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,20 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CalendarService {
     private final CalendarAppender calendarAppender;
     private final CalendarReader calendarReader;
-    //TODO 패키지 순환참조 해결
-    private final RecruitReader recruitReader;
 
     public CreateCalendarResponse createCalendar(CreateCalendarRequest request) {
         Calendar calendar = request.toEntity();
         Calendar savedCalendar = calendarAppender.append(calendar);
         return CreateCalendarResponse.from(savedCalendar);
-    }
-
-    public CreateLinkedCalenderResponse createLinkedCalender(CreateLinkedCalendarRequest request) {
-        Recruit recruit = recruitReader.findRecruitById(request.recruitId());
-        CreateCalendarRequest calendarRequest = CreateCalendarRequest.from(recruit, request.recruitUrl());
-        Calendar savedCalendar = calendarAppender.append(calendarRequest.toEntity());
-        return new CreateLinkedCalenderResponse(request.recruitId(), savedCalendar.getId());
     }
 
     public GetCalendarResponse getCalendar(Long id) {

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/RecruitLinkedCalendarController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/RecruitLinkedCalendarController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/calendars/linked")
+@RequestMapping("/calendars/link")
 @RequiredArgsConstructor
 public class RecruitLinkedCalendarController {
 
@@ -16,5 +16,10 @@ public class RecruitLinkedCalendarController {
     @PostMapping
     public CreateLinkedCalenderResponse createLinkedCalender(@RequestBody CreateLinkedCalendarRequest request) {
         return recruitLinkedCalendarService.createLinkedCalender(request);
+    }
+
+    @PatchMapping("/{id}/unlink")
+    public void unlinkCalendar(@PathVariable Long id) {
+        recruitLinkedCalendarService.unlinkCalendar(id);
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/RecruitLinkedCalendarController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/controller/RecruitLinkedCalendarController.java
@@ -1,0 +1,20 @@
+package com.clubber.ClubberServer.domain.recruit.controller;
+
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalendarRequest;
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalenderResponse;
+import com.clubber.ClubberServer.domain.recruit.service.RecruitLinkedCalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/calendars/linked")
+@RequiredArgsConstructor
+public class RecruitLinkedCalendarController {
+
+    private final RecruitLinkedCalendarService recruitLinkedCalendarService;
+
+    @PostMapping
+    public CreateLinkedCalenderResponse createLinkedCalender(@RequestBody CreateLinkedCalendarRequest request) {
+        return recruitLinkedCalendarService.createLinkedCalender(request);
+    }
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/recruitCalendar/CreateLinkedCalendarRequest.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/recruitCalendar/CreateLinkedCalendarRequest.java
@@ -1,4 +1,4 @@
-package com.clubber.ClubberServer.domain.calendar.dto;
+package com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar;
 
 public record CreateLinkedCalendarRequest(
         Long recruitId,

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/recruitCalendar/CreateLinkedCalenderResponse.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/dto/recruitCalendar/CreateLinkedCalenderResponse.java
@@ -1,4 +1,4 @@
-package com.clubber.ClubberServer.domain.calendar.dto;
+package com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar;
 
 public record CreateLinkedCalenderResponse(
         Long recruitId,

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/implement/RecruitReader.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/implement/RecruitReader.java
@@ -1,5 +1,6 @@
 package com.clubber.ClubberServer.domain.recruit.implement;
 
+import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
 import com.clubber.ClubberServer.domain.recruit.exception.RecruitNotFoundException;
@@ -39,5 +40,10 @@ public class RecruitReader {
 
     public Page<Recruit> findAllRecruits(Pageable pageable) {
         return recruitRepository.queryAllRecruits(pageable);
+    }
+
+    public Recruit findByCalendar(Calendar calendar) {
+        return recruitRepository.findByCalendar(calendar)
+                .orElseThrow(() -> RecruitNotFoundException.EXCEPTION);
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/repository/RecruitRepository.java
@@ -1,10 +1,12 @@
 package com.clubber.ClubberServer.domain.recruit.repository;
 
+import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,4 +19,6 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long>, Recruit
            "OR r.endAt BETWEEN :startOfMonth AND :endOfMonth) " +
            "AND r.isDeleted = false")
     List<Recruit> findRecruitsWithinDateRange(LocalDateTime startOfMonth, LocalDateTime endOfMonth);
+
+    Optional<Recruit> findByCalendar(Calendar calendar);
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
@@ -1,6 +1,10 @@
 package com.clubber.ClubberServer.domain.recruit.service;
 
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalendarRequest;
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalenderResponse;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
+import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
 import com.clubber.ClubberServer.domain.recruit.implement.RecruitReader;
@@ -14,10 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecruitLinkedCalendarService {
     private final RecruitReader recruitReader;
     private final CalendarReader calendarReader;
+    private final CalendarAppender calendarAppender;
 
     public void unlinkCalendar(Long calendarId) {
         Calendar calendar = calendarReader.readById(calendarId);
         Recruit recruit = recruitReader.findByCalendar(calendar);
         recruit.unlink();
+    }
+
+    public CreateLinkedCalenderResponse createLinkedCalender(CreateLinkedCalendarRequest request) {
+        Recruit recruit = recruitReader.findRecruitById(request.recruitId());
+        CreateCalendarRequest calendarRequest = CreateCalendarRequest.from(recruit, request.recruitUrl());
+        Calendar savedCalendar = calendarAppender.append(calendarRequest.toEntity());
+        return new CreateLinkedCalenderResponse(request.recruitId(), savedCalendar.getId());
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
@@ -1,12 +1,12 @@
 package com.clubber.ClubberServer.domain.recruit.service;
 
 import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
-import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalendarRequest;
-import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalenderResponse;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalendarRequest;
+import com.clubber.ClubberServer.domain.recruit.dto.recruitCalendar.CreateLinkedCalenderResponse;
 import com.clubber.ClubberServer.domain.recruit.implement.RecruitReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,16 +20,16 @@ public class RecruitLinkedCalendarService {
     private final CalendarReader calendarReader;
     private final CalendarAppender calendarAppender;
 
-    public void unlinkCalendar(Long calendarId) {
-        Calendar calendar = calendarReader.readById(calendarId);
-        Recruit recruit = recruitReader.findByCalendar(calendar);
-        recruit.unlink();
-    }
-
     public CreateLinkedCalenderResponse createLinkedCalender(CreateLinkedCalendarRequest request) {
         Recruit recruit = recruitReader.findRecruitById(request.recruitId());
         CreateCalendarRequest calendarRequest = CreateCalendarRequest.from(recruit, request.recruitUrl());
         Calendar savedCalendar = calendarAppender.append(calendarRequest.toEntity());
         return new CreateLinkedCalenderResponse(request.recruitId(), savedCalendar.getId());
+    }
+
+    public void unlinkCalendar(Long calendarId) {
+        Calendar calendar = calendarReader.readById(calendarId);
+        Recruit recruit = recruitReader.findByCalendar(calendar);
+        recruit.unlink();
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
@@ -1,0 +1,23 @@
+package com.clubber.ClubberServer.domain.recruit.service;
+
+import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
+import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
+import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
+import com.clubber.ClubberServer.domain.recruit.implement.RecruitReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecruitLinkedCalendarService {
+    private final RecruitReader recruitReader;
+    private final CalendarReader calendarReader;
+
+    public void unlinkCalendar(Long calendarId) {
+        Calendar calendar = calendarReader.readById(calendarId);
+        Recruit recruit = recruitReader.findByCalendar(calendar);
+        recruit.unlink();
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
#832 
연동 캘린더의 경우 Recruit 패키지를 의존하고 있었기에, 기존 Calendar 패키지에서 분리 
=> Recruit 패키지에서만 Calendar 패키지를 의존하도록 순환참조 방지 

## Key Changes
- [ ] 연동 해제 API 구현 
- [ ] 연동 모집글 calendar 저장 API 이동  

## ETC 
