### PR TITLE
feat : 관리자 캘린더 조회 시 필터 기준 추가

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
@@ -1,6 +1,7 @@
 package com.clubber.ClubberServer.domain.calendar.controller;
 
 import com.clubber.ClubberServer.domain.calendar.dto.*;
+import com.clubber.ClubberServer.domain.calendar.repository.CalendarFilterType;
 import com.clubber.ClubberServer.domain.calendar.service.CalendarAdminService;
 import com.clubber.ClubberServer.global.common.page.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
@@ -1,7 +1,6 @@
 package com.clubber.ClubberServer.domain.calendar.controller;
 
 import com.clubber.ClubberServer.domain.calendar.dto.*;
-import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.calendar.service.CalendarAdminService;
 import com.clubber.ClubberServer.global.common.page.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
@@ -25,8 +25,8 @@ public class CalendarAdminController {
 
     @GetMapping
     @Operation(summary = "캘린더 목록 (페이지) 조회")
-    public PageResponse<Calendar> getCalendars(Pageable pageable) {
-        return calendarService.getCalenderPages(pageable);
+    public PageResponse<GetCalendarResponse> getCalendars(Pageable pageable, @RequestParam CalendarFilterType calendarFilterType) {
+        return calendarService.getCalenderPages(pageable, calendarFilterType);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/dto/CalendarFilterType.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/dto/CalendarFilterType.java
@@ -1,0 +1,8 @@
+package com.clubber.ClubberServer.domain.calendar.dto;
+
+public enum CalendarFilterType {
+    ALL,
+    RECRUITING,
+    CLOSED,
+    ALWAYS;
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
@@ -28,18 +28,18 @@ public class CalendarReader {
 
     public Calendar readById(Long id) {
         return calendarRepository.findCalendarByIdAndIsDeleted(id, false)
-            .orElseThrow(() -> CalendarNotFoundException.EXCEPTION);
+                .orElseThrow(() -> CalendarNotFoundException.EXCEPTION);
     }
 
     public List<Calendar> findCalendarsByDateRangeAndTypes(LocalDateTime startOfMonth,
-        LocalDateTime endOfMonth,
-        List<RecruitType> recruitTypes) {
+                                                           LocalDateTime endOfMonth,
+                                                           List<RecruitType> recruitTypes) {
         return calendarRepository.findCalendarsWithinDateRange(startOfMonth, endOfMonth,
-            recruitTypes);
+                recruitTypes);
     }
 
     public List<GetAlwaysCalendarResponse> findCalendarsByEndDateAndType(LocalDateTime endOfMonth,
-        RecruitType recruitType) {
+                                                                         RecruitType recruitType) {
         return calendarRepository.findAlwaysRecruitCreatedBefore(endOfMonth, recruitType);
     }
 

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
@@ -1,6 +1,6 @@
 package com.clubber.ClubberServer.domain.calendar.implement;
 
-import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
+import com.clubber.ClubberServer.domain.calendar.repository.CalendarFilterType;
 import com.clubber.ClubberServer.domain.calendar.dto.GetAlwaysCalendarResponse;
 import com.clubber.ClubberServer.domain.calendar.dto.GetCalendarResponse;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/implement/CalendarReader.java
@@ -1,11 +1,14 @@
 package com.clubber.ClubberServer.domain.calendar.implement;
 
+import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
 import com.clubber.ClubberServer.domain.calendar.dto.GetAlwaysCalendarResponse;
+import com.clubber.ClubberServer.domain.calendar.dto.GetCalendarResponse;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.calendar.exception.CalendarNotFoundException;
 import com.clubber.ClubberServer.domain.calendar.repository.CalendarRepository;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
+import com.clubber.ClubberServer.global.common.page.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -40,8 +43,10 @@ public class CalendarReader {
         return calendarRepository.findAlwaysRecruitCreatedBefore(endOfMonth, recruitType);
     }
 
-    public Page<Calendar> readClubCalendarPage(Club club, Pageable pageable) {
-        return calendarRepository.findCalendarByClubAndIsDeleted(club, false, pageable);
+    public PageResponse<GetCalendarResponse> readClubCalendarPage(Club club, CalendarFilterType calendarFilterType, Pageable pageable) {
+        Page<Calendar> calendarPages = calendarRepository.findCalendarByClubAndIsDeleted(club, calendarFilterType, pageable);
+        Page<GetCalendarResponse> pageDtos = calendarPages.map(GetCalendarResponse::from);
+        return PageResponse.of(pageDtos);
     }
 
     public boolean isExistInSameMonth(RecruitType recruitType, YearMonth recruitYearMonth, Club club) {

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
@@ -11,5 +11,6 @@ import java.time.LocalDateTime;
 
 public interface CalendarCustomRepository {
     boolean isExistByRecruitTypeAndBetweenPeriod(RecruitType recruitType, Club club, LocalDateTime startOfMonth, LocalDateTime endOfMonth, LocalDateTime startOfThisMonth, LocalDateTime endOfThisMonth);
+
     Page<Calendar> findCalendarByClubAndIsDeleted(Club club, CalendarFilterType calendarFilterType, Pageable pageable);
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
@@ -1,6 +1,5 @@
 package com.clubber.ClubberServer.domain.calendar.repository;
 
-import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepository.java
@@ -1,10 +1,15 @@
 package com.clubber.ClubberServer.domain.calendar.repository;
 
+import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
+import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 
 public interface CalendarCustomRepository {
     boolean isExistByRecruitTypeAndBetweenPeriod(RecruitType recruitType, Club club, LocalDateTime startOfMonth, LocalDateTime endOfMonth, LocalDateTime startOfThisMonth, LocalDateTime endOfThisMonth);
+    Page<Calendar> findCalendarByClubAndIsDeleted(Club club, CalendarFilterType calendarFilterType, Pageable pageable);
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.clubber.ClubberServer.domain.calendar.repository;
 
-import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
@@ -50,7 +50,7 @@ public class CalendarCustomRepositoryImpl implements CalendarCustomRepository {
         return calendar.endAt.desc();
     }
 
-    public Page<Calendar> findCalendarByClubAndIsDeleted(Club club, CalendarFilterType calendarFilterType, Pageable pageable){
+    public Page<Calendar> findCalendarByClubAndIsDeleted(Club club, CalendarFilterType calendarFilterType, Pageable pageable) {
         List<Calendar> calendars = queryFactory.selectFrom(calendar)
                 .where(
                         calendar.isDeleted.eq(false),

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarCustomRepositoryImpl.java
@@ -1,14 +1,24 @@
 package com.clubber.ClubberServer.domain.calendar.repository;
 
+import com.clubber.ClubberServer.domain.calendar.dto.CalendarFilterType;
+import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.clubber.ClubberServer.domain.calendar.entity.QCalendar.calendar;
+import static com.clubber.ClubberServer.domain.recruit.domain.RecruitType.ALWAYS;
 
 @RequiredArgsConstructor
 public class CalendarCustomRepositoryImpl implements CalendarCustomRepository {
@@ -27,8 +37,59 @@ public class CalendarCustomRepositoryImpl implements CalendarCustomRepository {
     }
 
     private BooleanExpression betweenCalendarPeriod(RecruitType recruitType, LocalDateTime startOfMonth, LocalDateTime endOfMonth, LocalDateTime startOfThisMonth, LocalDateTime endOfThisMonth) {
-        if (recruitType == RecruitType.ALWAYS)
+        if (recruitType == ALWAYS)
             return calendar.createdAt.between(startOfThisMonth, endOfThisMonth);
         return calendar.startAt.between(startOfMonth, endOfMonth);
     }
+
+    private OrderSpecifier<LocalDateTime> descCreatedAt() {
+        return calendar.createdAt.desc();
+    }
+
+    private OrderSpecifier<LocalDateTime> descEndAt() {
+        return calendar.endAt.desc();
+    }
+
+    public Page<Calendar> findCalendarByClubAndIsDeleted(Club club, CalendarFilterType calendarFilterType, Pageable pageable){
+        List<Calendar> calendars = queryFactory.selectFrom(calendar)
+                .where(
+                        calendar.isDeleted.eq(false),
+                        calendar.club.eq(club),
+                        getEq(calendarFilterType))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrder(calendarFilterType).toArray(OrderSpecifier[]::new))
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(calendar.count())
+                .from(calendar)
+                .where(
+                        calendar.isDeleted.eq(false),
+                        calendar.club.eq(club),
+                        getEq(calendarFilterType));
+
+        return PageableExecutionUtils.getPage(calendars, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier<?>> getOrder(CalendarFilterType calendarFilterType) {
+        return switch (calendarFilterType) {
+            case ALL, ALWAYS -> List.of(descCreatedAt());
+            case RECRUITING -> List.of(alwaysLast, descEndAt());
+            case CLOSED -> List.of(descEndAt());
+        };
+    }
+
+    private BooleanExpression getEq(CalendarFilterType calendarFilterType) {
+        return switch (calendarFilterType) {
+            case ALL -> null;
+            case RECRUITING -> calendar.endAt.after(LocalDateTime.now()).and(calendar.recruitType.eq(ALWAYS));
+            case CLOSED -> calendar.endAt.before(LocalDateTime.now());
+            case ALWAYS -> calendar.recruitType.eq(ALWAYS);
+        };
+    }
+
+    private final OrderSpecifier<Integer> alwaysLast = new CaseBuilder()
+            .when(calendar.recruitType.eq(RecruitType.ALWAYS)).then(1)
+            .otherwise(0)
+            .asc();
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarFilterType.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarFilterType.java
@@ -1,4 +1,4 @@
-package com.clubber.ClubberServer.domain.calendar.dto;
+package com.clubber.ClubberServer.domain.calendar.repository;
 
 public enum CalendarFilterType {
     ALL,

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarRepository.java
@@ -38,7 +38,4 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long>, Calen
     );
 
     Optional<Calendar> findCalendarByIdAndIsDeleted(Long id, boolean deleted);
-
-    Page<Calendar> findCalendarByClubAndIsDeleted(Club club, Boolean isDeleted, Pageable pageable);
-
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/repository/CalendarRepository.java
@@ -2,17 +2,13 @@ package com.clubber.ClubberServer.domain.calendar.repository;
 
 import com.clubber.ClubberServer.domain.calendar.dto.GetAlwaysCalendarResponse;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
-import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long>, CalendarCustomRepository {
 

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
@@ -6,6 +6,7 @@ import com.clubber.ClubberServer.domain.calendar.dto.*;
 import com.clubber.ClubberServer.domain.calendar.entity.Calendar;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
+import com.clubber.ClubberServer.domain.calendar.repository.CalendarFilterType;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
 import com.clubber.ClubberServer.global.common.page.PageResponse;

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
@@ -34,11 +34,10 @@ public class CalendarAdminService {
         return CreateCalendarResponse.from(savedCalendar);
     }
 
-    public PageResponse<Calendar> getCalenderPages(Pageable pageable) {
+    public PageResponse<GetCalendarResponse> getCalenderPages(Pageable pageable, CalendarFilterType calendarFilterType) {
         Admin admin = adminReader.getCurrentAdmin();
         Club club = admin.getClub();
-        Page<Calendar> calendars = calendarReader.readClubCalendarPage(club, pageable);
-        return PageResponse.of(calendars);
+        return calendarReader.readClubCalendarPage(club, calendarFilterType, pageable);
     }
 
     public GetCalendarResponse getCalendar(Long id) {

--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/service/CalendarAdminService.java
@@ -10,7 +10,6 @@ import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
 import com.clubber.ClubberServer.global.common.page.PageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
#859 

## Key Changes
- [ ] Enum CalendarFilterType을 새로 생성하여 order, where절의 동적쿼리 작성

## ETC 
"등록순" 정렬기준은 추후에 구현 