### PR TITLE
refactor : recruit - calendar 도메인 로직 리팩토링

### DIFF
--- a/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/calendar/controller/CalendarAdminController.java
@@ -17,12 +17,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/admins/calendars")
 @Tag(name = "[관리자 캘린더 관련 API]")
 public class CalendarAdminController {
-    private final CalendarAdminService calendarService;
+    private final CalendarAdminService calendarAdminService;
 
     @PostMapping
     @Operation(summary = "미연동 캘린더 생성")
     public CreateCalendarResponse createCalendar(@RequestBody CreateCalendarRequest request) {
-        return calendarService.createCalendar(request);
+        return calendarAdminService.createCalendar(request);
     }
 
     @GetMapping
@@ -32,30 +32,30 @@ public class CalendarAdminController {
             @RequestParam(required = false) CalendarStatus calendarStatus,
             @RequestParam(required = false) RecruitType recruitType,
             @RequestParam(required = false) OrderStatus orderStatus) {
-        return calendarService.getCalenderPages(pageable, calendarStatus, recruitType, orderStatus);
+        return calendarAdminService.getCalenderPages(pageable, calendarStatus, recruitType, orderStatus);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "특정 캘린더 (단일) 조회")
     public GetCalendarResponse getCalendar(@PathVariable Long id) {
-        return calendarService.getCalendar(id);
+        return calendarAdminService.getCalendar(id);
     }
 
     @PatchMapping("/{id}")
     @Operation(summary = "특정 캘린더 수정")
     public void updateCalendar(@PathVariable Long id, @RequestBody UpdateCalendarRequest request) {
-        calendarService.updateCalendar(request, id);
+        calendarAdminService.updateCalendar(request, id);
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "특정 캘린더 삭제")
     public void deleteCalendar(@PathVariable Long id) {
-        calendarService.deleteCalendar(id);
+        calendarAdminService.deleteCalendar(id);
     }
 
     @PostMapping("/duplicate")
     @Operation(summary = "캘린더 중복 여부 확인 API")
     public GetCalendarDuplicateResponse getCalendarDuplicate(@RequestBody GetCalendarDuplicateRequest request) {
-        return calendarService.checkDuplicateCalendar(request);
+        return calendarAdminService.checkDuplicateCalendar(request);
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
@@ -67,6 +67,9 @@ public class Recruit extends BaseEntity {
     private List<RecruitImage> recruitImages = new ArrayList<>();
 
     public void delete() {
+        if (isCalendarLinked()) {
+            calendar.delete();
+        }
         this.isDeleted = true;
     }
 

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/domain/Recruit.java
@@ -4,6 +4,7 @@ import com.clubber.ClubberServer.domain.calendar.domain.Calendar;
 import com.clubber.ClubberServer.domain.calendar.domain.CalendarStatus;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.common.BaseEntity;
+import com.clubber.ClubberServer.domain.recruit.exception.RecruitAlreadyCalendarUnlinkedException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -91,6 +92,9 @@ public class Recruit extends BaseEntity {
     }
 
     public void unlinkCalendar() {
+        if (!isCalendarLinked()) {
+            throw RecruitAlreadyCalendarUnlinkedException.EXCEPTION;
+        }
         this.calendar.unlink();
         this.calendar = null;
     }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/exception/RecruitAlreadyCalendarUnlinkedException.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/exception/RecruitAlreadyCalendarUnlinkedException.java
@@ -1,0 +1,14 @@
+package com.clubber.ClubberServer.domain.recruit.exception;
+
+import com.clubber.ClubberServer.global.exception.BaseException;
+
+import static com.clubber.ClubberServer.domain.recruit.exception.RecruitErrorCode.RECRUIT_ALREADY_CALENDAR_UNLINKED;
+
+public class RecruitAlreadyCalendarUnlinkedException extends BaseException {
+
+    public static final BaseException EXCEPTION = new RecruitAlreadyCalendarUnlinkedException();
+
+    private RecruitAlreadyCalendarUnlinkedException() {
+        super(RECRUIT_ALREADY_CALENDAR_UNLINKED);
+    }
+}

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/exception/RecruitErrorCode.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/exception/RecruitErrorCode.java
@@ -20,6 +20,7 @@ public enum RecruitErrorCode implements BaseErrorCode {
         "startAt과 endAt은 필수입니다."),
     RECRUIT_PERIOD_NOT_ALLOWED(HttpStatus.BAD_REQUEST.value(), "RECRUIT_400_7",
             "상시모집의 경우 startAt과 endAt이 null이어야 합니다."),
+    RECRUIT_ALREADY_CALENDAR_UNLINKED(HttpStatus.BAD_REQUEST.value(), "RECRUIT_400_8", "연동되어있지 않은 캘린더를 연동해제할 수 없습니다."),
     RECRUIT_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "RECRUIT_403_1", "모집글 접근 권한이 없습니다."),
     RECRUIT_DELETE_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "RECRUIT_403_2", "모집글 삭제 권한이 없습니다."),
     RECRUIT_COMMENT_UNAUTHORIZED(HttpStatus.FORBIDDEN.value(), "RECRUIT_403_3", "댓글 권한이 없습니다."),

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/implement/RecruitAppender.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/implement/RecruitAppender.java
@@ -1,6 +1,8 @@
 package com.clubber.ClubberServer.domain.recruit.implement;
 
+import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
+import com.clubber.ClubberServer.domain.recruit.dto.UpdateRecruitRequest;
 import com.clubber.ClubberServer.domain.recruit.repository.RecruitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RecruitAppender {
     private final RecruitRepository recruitRepository;
+    private final CalendarAppender calendarAppender;
+
     public void delete(Recruit recruit) {
         recruit.delete();
     }
@@ -21,5 +25,19 @@ public class RecruitAppender {
 
     public Recruit append(Recruit recruit) {
         return recruitRepository.save(recruit);
+    }
+
+    public Boolean checkAndUpdateCalendarLink(Recruit recruit, UpdateRecruitRequest requestPage) {
+        Boolean requestToLink = requestPage.getIsCalendarLinked();
+        Boolean shouldCreateCalendar = Boolean.FALSE;
+
+        if (recruit.isCalendarLinked() && !requestToLink) {  // 연동된 캘린더의 해제
+            recruit.unlinkCalendar();
+        } else if (recruit.isCalendarLinked() && requestToLink) {// 연동된 캘린더의 연동 유지
+            calendarAppender.update(recruit.getCalendar(), requestPage.getTitle(), requestPage.getRecruitType(), requestPage.getStartAt(), requestPage.getEndAt());
+        } else if (!recruit.isCalendarLinked() && requestToLink) { // 새로 연동
+            shouldCreateCalendar = Boolean.TRUE;
+        }
+        return shouldCreateCalendar;
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitLinkedCalendarService.java
@@ -2,21 +2,18 @@ package com.clubber.ClubberServer.domain.recruit.service;
 
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
 import com.clubber.ClubberServer.domain.admin.implement.AdminReader;
-import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
 import com.clubber.ClubberServer.domain.calendar.domain.Calendar;
+import com.clubber.ClubberServer.domain.calendar.dto.CreateCalendarRequest;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarAppender;
 import com.clubber.ClubberServer.domain.calendar.implement.CalendarReader;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
-import com.clubber.ClubberServer.domain.recruit.domain.RecruitType;
 import com.clubber.ClubberServer.domain.recruit.dto.CreateLinkedCalendarRequest;
 import com.clubber.ClubberServer.domain.recruit.dto.CreateLinkedCalenderResponse;
 import com.clubber.ClubberServer.domain.recruit.implement.RecruitReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -42,25 +39,10 @@ public class RecruitLinkedCalendarService {
         return new CreateLinkedCalenderResponse(request.recruitId(), savedCalendar.getId());
     }
 
-
-    @Transactional
-    public void syncCalendarWithRecruit(Recruit recruit, String title, RecruitType recruitType,
-                                        LocalDateTime startAt, LocalDateTime endAt) {
-        Calendar calendar = calendarReader.readById(recruit.getCalendar().getId());
-        calendarAppender.update(calendar, title, recruitType, startAt, endAt);
-    }
-
-
     @Transactional
     public void unlinkCalendar(Long calendarId) {
         Calendar calendar = calendarReader.readById(calendarId);
         Recruit recruit = recruitReader.findByCalendar(calendar);
         recruit.unlinkCalendar();
-    }
-
-    @Transactional
-    public void deleteLinkedCalendar(Long calendarId) {
-        Calendar calendar = calendarReader.readById(calendarId);
-        calendarAppender.delete(calendar);
     }
 }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -117,10 +117,6 @@ public class RecruitService {
         recruitAppender.delete(recruit);
         recruitImageAppender.deleteRecruitImages(recruit.getRecruitImages());
 
-        if (recruit.isCalendarLinked()) {
-            recruitLinkedCalendarService.deleteLinkedCalendar(recruit.getCalendar().getId());
-        }
-
         List<ImageVO> imageUrls = recruitMapper.getDeletedRecruitImages(recruit);
         return DeleteRecruitByIdResponse.from(recruit, imageUrls);
     }

--- a/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/clubber/ClubberServer/domain/recruit/service/RecruitService.java
@@ -1,21 +1,12 @@
 package com.clubber.ClubberServer.domain.recruit.service;
 
-import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
-
 import com.clubber.ClubberServer.domain.admin.domain.Admin;
 import com.clubber.ClubberServer.domain.admin.implement.AdminReader;
 import com.clubber.ClubberServer.domain.club.domain.Club;
 import com.clubber.ClubberServer.domain.club.implement.ClubReader;
 import com.clubber.ClubberServer.domain.recruit.domain.Recruit;
 import com.clubber.ClubberServer.domain.recruit.domain.RecruitImage;
-import com.clubber.ClubberServer.domain.recruit.dto.DeleteRecruitByIdResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.GetOneAdminRecruitResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.GetOneRecruitInListResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.GetOneRecruitWithClubResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.PostRecruitRequest;
-import com.clubber.ClubberServer.domain.recruit.dto.PostRecruitResponse;
-import com.clubber.ClubberServer.domain.recruit.dto.UpdateRecruitRequest;
-import com.clubber.ClubberServer.domain.recruit.dto.UpdateRecruitResponse;
+import com.clubber.ClubberServer.domain.recruit.dto.*;
 import com.clubber.ClubberServer.domain.recruit.dto.mainPage.GetRecruitsMainPageResponse;
 import com.clubber.ClubberServer.domain.recruit.exception.RecruitImageDeleteRemainDuplicatedException;
 import com.clubber.ClubberServer.domain.recruit.exception.RecruitImageNotFoundException;
@@ -29,17 +20,20 @@ import com.clubber.ClubberServer.domain.recruit.repository.RecruitImageRepositor
 import com.clubber.ClubberServer.domain.recruit.repository.RecruitRepository;
 import com.clubber.ClubberServer.global.common.page.PageResponse;
 import com.clubber.ClubberServer.global.vo.image.ImageVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import static com.clubber.ClubberServer.global.common.consts.ClubberStatic.IMAGE_SERVER;
 
 @Service
 @RequiredArgsConstructor
@@ -54,7 +48,6 @@ public class RecruitService {
     private final RecruitImageAppender recruitImageAppender;
     private final RecruitImageRepository recruitImageRepository;
     private final RecruitMapper recruitMapper;
-    private final RecruitLinkedCalendarService recruitLinkedCalendarService;
 
     @Transactional(readOnly = true)
     public PageResponse<GetOneRecruitInListResponse> getRecruitsByClubId(Long clubId,
@@ -221,19 +214,7 @@ public class RecruitService {
             recruitImage.updateOrderNum(order.getAndIncrement());
         }
 
-        Boolean shouldCreateCalendar = Boolean.FALSE;
-        if (recruit.isCalendarLinked()
-            && !requestPage.getIsCalendarLinked()) {  // 연동된 캘린더의 해제
-            recruit.unlinkCalendar();
-        } else if (recruit.isCalendarLinked()
-            && requestPage.getIsCalendarLinked()) { // 연동된 캘린더의 연동 유지
-            recruitLinkedCalendarService.syncCalendarWithRecruit(recruit, requestPage.getTitle(),
-                requestPage.getRecruitType(), requestPage.getStartAt(), requestPage.getEndAt());
-        } else if (!recruit.isCalendarLinked()
-            && requestPage.getIsCalendarLinked()) { // 새로 연동
-            shouldCreateCalendar = Boolean.TRUE;
-        }
-
+        Boolean shouldCreateCalendar = recruitAppender.checkAndUpdateCalendarLink(recruit, requestPage);
         return UpdateRecruitResponse.of(recruit, requestPage.getImages(),
             requestPage.getIsCalendarLinked(), shouldCreateCalendar);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 개요 및 이슈. -->
<!---- Resolves: #(Isuue Number) -->
#909 

## Key Changes
- [x] recruit 삭제시 calendar의 삭제 로직까지 함께 도메인 계층에서 호출 
- [x] 연동 해제시 NPE 방지를 위해 연동 여부 검증 로직 & 예외 추가 
- [x] recruit 수정시 calendar 반영 로직(sync recruit - calendar등)은 implement(RecruitAppender)에서 담당하게 수정 

## ETC 
